### PR TITLE
Adding and using a jenkins user with uid 1200

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabl
     # Autoconf
     autoconf automake libtool \
     # Various other tools
-    git rpm-build distcc-server file wget openssl hwloc nghttp2 libnghttp2-devel; \
+    sudo git rpm-build distcc-server file wget openssl hwloc nghttp2 libnghttp2-devel; \
     # Devel packages that ATS needs
     yum -y install openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
     xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
@@ -40,3 +40,18 @@ RUN source /etc/profile
 RUN go get github.com/summerwind/h2spec/cmd/h2spec
 RUN cp /root/go/bin/h2spec /usr/local/bin
 RUN yum clean all
+
+# Add the CI's test user. N.B: 1200 is the uid that our jenkins user is
+# configured with, so that has to be used. Otherwise there will be permissions
+# issues.
+ARG username=jenkins
+ARG uid=1200
+RUN useradd \
+    --home-dir /home/${username} \
+    --groups users,wheel \
+    --uid ${uid} \
+    --shell /bin/bash \
+    --create-home \
+    ${username}
+RUN echo "${username} ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN chown -R ${username} /home/${username}

--- a/docker/centos/build_h3_tools.sh
+++ b/docker/centos/build_h3_tools.sh
@@ -116,7 +116,16 @@ echo "Building nghttp2 ..."
 [ ! -d nghttp2 ] && git clone https://github.com/tatsuhiro-t/nghttp2.git
 cd nghttp2
 git checkout --track -b quic origin/quic
-git checkout d2e570c72e169ed88557ce5108df34d34d4f7f08
+# This commit will be removed whenever the nghttp2 author rebases origin/quic.
+# For reference, this commit is currently described as:
+#
+# commit cdf58e370e6a843b0965aabcd75908ca52633b60
+# Author: Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com>
+# Date:   Sat Mar 27 23:37:37 2021 +0900
+#
+#     Compile with the latest ngtcp2
+
+git checkout cdf58e370e6a843b0965aabcd75908ca52633b60
 autoreconf -if
 ./configure --prefix=${BASE} PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_PREFIX}/lib/pkgconfig CFLAGS="${CFLAGS}" CXXFLAGS="${CXXFLAGS}" LDFLAGS="${LDFLAGS}"
 ${MAKE} -j $(nproc)

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -3,7 +3,7 @@ pipeline {
 		docker {
 			registryUrl 'https://controller.trafficserver.org/'
 			image 'controller.trafficserver.org/ats/centos:8'
-			args '--init --cap-add=SYS_PTRACE --network=host -u root -v ${HOME}/ccache:/tmp/ccache:rw'
+			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'docker'
 		}
 	}
@@ -51,11 +51,11 @@ pipeline {
 				dir('src') {
 					sh '''
 					source /opt/rh/gcc-toolset-9/enable
-					update-crypto-policies --set LEGACY
+					sudo update-crypto-policies --set LEGACY
 
 					# Change permissions so that all files are readable
 					# (default user umask may change and make these unreadable)
-					chmod -R o+r .
+					sudo chmod -R o+r .
 					autoreconf -fiv
 					./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
 					make -j4
@@ -75,11 +75,11 @@ pipeline {
 						./autest.sh --ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox || true
 						if [ -n "$(ls -A /tmp/sandbox/)" ]; then
 							cp -rf /tmp/sandbox/ ${WORKSPACE}/output/${GITHUB_BRANC}/
-							chmod -R 777 ${WORKSPACE}
+							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						else
-							touch ${WORKSPACE}/output/${GITHUB_BRANC}/No_autest_failures
-							chmod -R 777 ${WORKSPACE}
+							sudo touch ${WORKSPACE}/output/${GITHUB_BRANC}/No_autest_failures
+							sudo chmod -R 777 ${WORKSPACE}
 							exit 0
 						fi
 						'''


### PR DESCRIPTION
We face frequent permissions problems with running our AuTests as the
root user. Files get created as root, then the running ATS process,
running as user nobody, cannot access these files. This change adds a
jenkins user with the same uid that our jenkins machines have (uid
1200). This helps the tests run more smoothly.