### PR TITLE
remove extra cleanWs call

### DIFF
--- a/jenkins/branch/in_tree.pipeline
+++ b/jenkins/branch/in_tree.pipeline
@@ -33,7 +33,6 @@ pipeline {
 		
 		stage('Clone') {
 			steps {
-				cleanWs()
 				dir('ci') {
 					git url: 'https://github.com/apache/trafficserver-ci',
 						branch: 'main'


### PR DESCRIPTION
added an extra cleanWs() call to in_tree.pipeline, this removes that.