### PR TITLE
autest.pipeline: make archive exclude sockets

### DIFF
--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -111,7 +111,9 @@ pipeline {
 
 	post {
 		always {
-			archiveArtifacts artifacts: 'output/**/*', fingerprint: false, allowEmptyArchive: true
+			// We exclude socket files because archiveArtifacts doesn't deal well with
+			// their file type.
+			archiveArtifacts artifacts: 'output/**/*', fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock'
 		}
 		cleanup {
 			cleanWs()


### PR DESCRIPTION
archiveArtifacts does not deal well with sockets. Exclude them from the
archived sandbox when there is a test failure.