### PR TITLE
disable running clang-analyzer for 8.1.x branch for now

### DIFF
--- a/jenkins/bin/clang-analyzer.sh
+++ b/jenkins/bin/clang-analyzer.sh
@@ -23,6 +23,8 @@ test -z "${WORKSPACE}" && WORKSPACE=".."
 mkdir -p ${WORKSPACE}/output/${GITHUB_BRANCH}
 head -1 README
 
+grep -q 80010 configure.ac && echo "8.1.x branch detected, stop here!" && exit 0
+
 autoreconf -fiv
 scan-build-10 --keep-cc \
   ./configure --enable-experimental-plugins --with-luajit


### PR DESCRIPTION
this is the current default in the old ci.