### PR TITLE
add catch to allow branch build pipeline to continue even on os failure

### DIFF
--- a/jenkins/branch/branch_build.pipeline
+++ b/jenkins/branch/branch_build.pipeline
@@ -130,7 +130,9 @@ pipeline {
 		stage('OS Builds') {
 			steps {
 				script {
-					doParallelBuilds()
+				  catchError(buildResult: 'FAILURE', stageResult: 'FAILURE') {
+					  doParallelBuilds()
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This allows branch builds to run all post tests to completion even if an os build fails.