### PR TITLE
change syntax for specifying docker image

### DIFF
--- a/jenkins/branch/os_build.pipeline
+++ b/jenkins/branch/os_build.pipeline
@@ -2,7 +2,7 @@ pipeline {
 	agent {
 		docker {
 			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/${DISTRO}'
+			image 'controller.trafficserver.org/ats/' + env.DISTRO
 			args '-v /home/jenkins/ccache:/tmp/ccache:rw --network=host'
 			label 'branch'
 		}


### PR DESCRIPTION
Change how registry image name is built for the OS image.  Broken by a plugin update.