### PR TITLE
Use fedora:32 until gcc-12 warnings are fixed

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:36'
+            image 'ats/fedora:32'
             //registryUrl 'https://controller.trafficserver.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
See:
https://github.com/apache/trafficserver/issues/8682