### PR TITLE
fedora.pipeline: fedora:32 -> fedora 36

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:32'
+            image 'ats/fedora:36'
             //registryUrl 'https://controller.trafficserver.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
This will compilation and linking with gcc-12.0.1.