### PR TITLE
Use /opt/openssl-quic for fedora:36

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -51,7 +51,8 @@ pipeline {
                         set -x
                         set -e
                         autoreconf -fiv
-                        ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
+                        # Remove the --with-openssl argument when we support OpenSSL 3.x.
+                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
                         make -j4 V=1 Q=
                         make -j 2 check VERBOSE=Y V=1
                         make install


### PR DESCRIPTION
fedora:36 has openssl-3.x by default. ATS doesn't support that yet. For
now use the 1.1.1m that we build into our fedora:36 image.