### PR TITLE
Use fedora:35 for PR checks

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:36'
+            image 'ats/fedora:35'
             //registryUrl 'https://controller.trafficserver.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
We're seeing frequent autoreconf failures with fedora:36. Hopefully
that's just because fedora:36 is currently beta. Switching to fedora:35.