### PR TITLE
fedora:32

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:35'
+            image 'ats/fedora:32'
             //registryUrl 'https://controller.trafficserver.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
Reverting to us using fedora:32 for now. fedora:35 fails autoconf on CI
with:

+ autoreconf -fiv
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I build
autoreconf: configure.ac: tracing
autoreconf: configure.ac: not using Libtool
autoreconf: running: /usr/bin/autoconf --force
/usr/bin/autoconf: This script requires a shell more modern than all
/usr/bin/autoconf: the shells that I found on your system.
/usr/bin/autoconf: Please tell bug-autoconf@gnu.org about your system,
/usr/bin/autoconf: including any error possibly output before this
/usr/bin/autoconf: message. Then install a modern shell, or manually run
/usr/bin/autoconf: the script under such a shell if you do have one.
autoreconf: /usr/bin/autoconf failed with exit status: 1