### PR TITLE
Specifying SHELL for fedora:35 autoreconf

### DIFF
--- a/jenkins/fedora.pipeline
+++ b/jenkins/fedora.pipeline
@@ -21,7 +21,7 @@ pipeline {
                 echo 'Starting build'
                 dir('src') {
                     sh('ls')
-                    sh('autoreconf -fiv')
+                    sh('SHELL=/bin/bash autoreconf -fiv')
                     sh('./configure --enable-experimental-plugins')
                     sh('make -j2')
                 }

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -46,11 +46,11 @@ pipeline {
                 dir('src') {
                     // For Jenkins debugging. We comit to the top of README in our debug PRs.
                     sh('head README')
-                    
+
                     sh '''#!/bin/bash
                         set -x
                         set -e
-                        autoreconf -fiv
+                        SHELL=/bin/bash autoreconf -fiv
                         # Remove the --with-openssl argument when we support OpenSSL 3.x.
                         ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
                         make -j4 V=1 Q=


### PR DESCRIPTION
autoreconf fails in CI sometimes. This seems to be due to SHELL issues.
Trying to address this by explicitly setting /bin/bash as the shell.