### PR TITLE
controller.trafficserver.org -> ci.trafficserver.apache.org

### DIFF
--- a/docker/cache-tests/Dockerfile
+++ b/docker/cache-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM controller.trafficserver.org/ats/debian:11
+FROM ci.trafficserver.apache.org/ats/debian:11
 
 EXPOSE 8000
 

--- a/docker/cache-tests/README.md
+++ b/docker/cache-tests/README.md
@@ -13,7 +13,7 @@ For this to work a desired clone of the cache-tests git repo
 needs to reside in /opt/cache-tests/cache-tests on the `controller`.
 
 Periodically this git repo should be updated which will require rebuilding
-the cache-tests image: `controller.trafficserver.org/ats/cache-tests`
+the cache-tests image: `ci.trafficserver.apache.org/ats/cache-tests`
 and restarting the Publishing server.
 
 Currently the `debian:11` image from the ats docker repo is used
@@ -45,8 +45,8 @@ git stash ; git fetch ; git pull ; git stash apply
 # rebuild and push cache-tests image
 cd /opt/cache-tests
 docker-compose build builder
-docker tag <hash> controller.trafficserver.org:5000/ats/cache-tests
-docker push controller.trafficserver.org:5000/ats/cache-tests
+docker tag <hash> ci.trafficserver.apache.org:5000/ats/cache-tests
+docker push ci.trafficserver.apache.org:5000/ats/cache-tests
 
 docker-compose up -d server
 ```

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'branch'
 		}

--- a/jenkins/branch/cache-tests.pipeline
+++ b/jenkins/branch/cache-tests.pipeline
@@ -10,8 +10,8 @@ pipeline {
 
 			agent {
 				docker {
-					registryUrl 'https://controller.trafficserver.org/'
-					image 'controller.trafficserver.org/ats/cache-tests'
+					registryUrl 'https://ci.trafficserver.apache.org/'
+					image 'ci.trafficserver.apache.org/ats/cache-tests'
 					args '--user root --init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 					label 'branch'
 				}

--- a/jenkins/branch/clang_analyzer.pipeline
+++ b/jenkins/branch/clang_analyzer.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/ubuntu:20.04'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/ubuntu:20.04'
 			args '-v /home/jenkins/clang-analyzer:/tmp/clang-analyzer:rw --network=host'
 			label 'branch'
 		}

--- a/jenkins/branch/clang_format.pipeline
+++ b/jenkins/branch/clang_format.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			label 'branch'
 			args '--network=host'
 		}

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'branch'
 		}

--- a/jenkins/branch/docs.pipeline
+++ b/jenkins/branch/docs.pipeline
@@ -5,8 +5,8 @@ pipeline {
 		stage('Build') {
 			agent {
 				docker {
-					image 'controller.trafficserver.org/ats/rockylinux:8'
-					registryUrl 'https://controller.trafficserver.org/'
+					image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+					registryUrl 'https://ci.trafficserver.apache.org/'
 					args '--network=host'
 					label 'branch'
 				}

--- a/jenkins/branch/in_tree.pipeline
+++ b/jenkins/branch/in_tree.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			args '--network=host -v "${HOME}"/ccache:/tmp/ccache:rw'
 			label 'branch'
 		}

--- a/jenkins/branch/os_build.pipeline
+++ b/jenkins/branch/os_build.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/' + env.DISTRO
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/' + env.DISTRO
 			args '-v /home/jenkins/ccache:/tmp/ccache:rw --network=host'
 			label 'branch'
 		}

--- a/jenkins/branch/out_of_tree.pipeline
+++ b/jenkins/branch/out_of_tree.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			args '--network=host -v "${HOME}"/ccache:/tmp/ccache:rw'
 			label 'branch'
 		}

--- a/jenkins/branch/rat.pipeline
+++ b/jenkins/branch/rat.pipeline
@@ -1,8 +1,8 @@
 pipeline {
 	agent {
 		docker {
-			registryUrl 'https://controller.trafficserver.org/'
-			image 'controller.trafficserver.org/ats/rockylinux:8'
+			registryUrl 'https://ci.trafficserver.apache.org/'
+			image 'ci.trafficserver.apache.org/ats/rockylinux:8'
 			label 'branch'
 			// We need host networking for clang-format to download
 			args '--network=host'

--- a/jenkins/fedora.pipeline
+++ b/jenkins/fedora.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/old_ci/fedora:30'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/old_ci/fedora:30'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
         }
     }

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
             label 'docker'
         }

--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/centos:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/centos:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
         }

--- a/jenkins/github/clang-analyzer.pipeline
+++ b/jenkins/github/clang-analyzer.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/ubuntu:20.04'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/ubuntu:20.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             args '-v /home/rooter/clang-analyzer:/tmp/clang-analyzer:rw'
             label 'docker'
         }

--- a/jenkins/github/clang-format-test.pipeline
+++ b/jenkins/github/clang-format-test.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             // We need host networking for clang-format to download
             args '--network host'

--- a/jenkins/github/clang-format.pipeline
+++ b/jenkins/github/clang-format.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             // We need host networking for clang-format to download
             args '--network host'

--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/debian:10'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/debian:10'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
         }

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             args '--network=host'
             label 'docker'
         }

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -2,7 +2,7 @@ pipeline {
     agent {
         docker {
             image 'ats/fedora:35'
-            //registryUrl 'https://controller.trafficserver.org/'
+            //registryUrl 'https://ci.trafficserver.apache.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'
         }

--- a/jenkins/github/rat.pipeline
+++ b/jenkins/github/rat.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             // We need host networking for clang-format to download
             args '--network host'

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/rockylinux:8'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/rockylinux:8'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
         }

--- a/jenkins/github/ubuntu-clang.pipeline
+++ b/jenkins/github/ubuntu-clang.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/ubuntu:20.04'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/ubuntu:20.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
         }
     }

--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/ubuntu:20.04'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/ubuntu:20.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'            
         }

--- a/jenkins/ubuntu-param.pipeline
+++ b/jenkins/ubuntu-param.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/old_ci/ubuntu:19.04'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/old_ci/ubuntu:19.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
         }
     }

--- a/jenkins/ubuntu.pipeline
+++ b/jenkins/ubuntu.pipeline
@@ -1,8 +1,8 @@
 pipeline {
     agent {
         docker {
-            image 'controller.trafficserver.org/ats/old_ci/ubuntu:19.04'
-            registryUrl 'https://controller.trafficserver.org/'
+            image 'ci.trafficserver.apache.org/ats/old_ci/ubuntu:19.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
         }
     }


### PR DESCRIPTION
ci.trafficserver.apache.org is the correct URL to use and it has the
correct externally facing cert as served by our controller's ATS. This
updates our scripts to use the ci.trafficserver.apache.org URL so that
people copying the image name from jenkins console output will be able
to use that locally if they so desire.