### PR TITLE
M4=/bin/m4 for fedora:35 autoreconf github builds

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -54,7 +54,7 @@ pipeline {
                         autoreconf_succeeded=0
                         for i in {1..5}
                         do
-                          if CONFIG_SHELL=/bin/bash autoreconf -fiv
+                          if M4=/bin/m4 CONFIG_SHELL=/bin/bash autoreconf -fiv
                           then
                             autoreconf_succeeded=1
                             break


### PR DESCRIPTION
Applying what we did for branch builds to the fedora github CI builds:
38a1eb4e87d4ff8c9feb6c81d72ce2addc83fbc2