### PR TITLE
fedora:36 is officially released. Use it in CI.

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:35'
+            image 'ats/fedora:36'
             //registryUrl 'https://ci.trafficserver.apache.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
This updates the github PR fedora build to use fedora:36.

I did an ATS master build with this locally and it all built. Updating CI to check this with each PR so it stays working.