### PR TITLE
Make the RAT license check pipeline more precise

### DIFF
--- a/jenkins/github/rat.pipeline
+++ b/jenkins/github/rat.pipeline
@@ -54,7 +54,7 @@ pipeline {
                         make rat | tee RAT.txt
 
                         # Mark as failed if there are any unknown licenses
-                        grep '0 Unknown Licenses' RAT.txt > /dev/null || exit -1
+                        grep '^0 Unknown Licenses' RAT.txt > /dev/null || exit -1
                         exit 0
                     '''
                 }


### PR DESCRIPTION
It turns out that we've been missing the libswoc license failures from
RAT because there are 30 failures, making the report contain this:

30 Unknown Licenses

Our grep currently sees the '0 Unknown Licenses' substring on this and
passes. This makes sure that the 0 is a leading zero at the start of the
line.

We must not merge this until some fix is made for the libswoc licenses
(either ignore them or update the libswoc licenses to be the more
verbose versions).