### PR TITLE
Enable strict docs generation for branch builds, exception for 8.1.x

### DIFF
--- a/jenkins/bin/docs.sh
+++ b/jenkins/bin/docs.sh
@@ -57,7 +57,12 @@ autoreconf -fi && ./configure --enable-docs
 cd doc
 echo "Building EN Docs"
 rm -rf docbuild/html
-make -j4 -e SPHINXOPTS="-D language='en'" html
+
+sphinxopts="-W -D language='en'"
+if [ "${GITHUB_BRANCH}" = "8.1.x" ]; then
+  sphinxopts="-D language='en'"
+fi
+make -j4 -e SPHINXOPTS="${sphinxopts}" html
 
 mkdir -p "${enoutdir}"
 cp -rf docbuild/html/* "${enoutdir}"

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -43,7 +43,7 @@ pipeline {
                 dir('src') {
                     // For Jenkins debugging. We comit to the top of README in our debug PRs.
                     sh('head README')
-                    
+
                     sh '''#!/bin/bash
                     set -x
                     # Skip if nothing in doc has changed
@@ -60,9 +60,9 @@ pipeline {
                     sudo chmod -R 777 . || exit 1
                     cd doc
                     pipenv install || exit 1
-                    
+
                     tmpfile=/tmp/build_the_docs.$$
-                    
+
                     cat << _END_OF_DOC_ > ${tmpfile}
 #!/bin/bash
 set -e
@@ -72,9 +72,13 @@ autoreconf -fi && ./configure --enable-docs
 cd doc
 echo "Building English Docs"
 rm -rf docbuild/html
-make -j4 -e SPHINXOPTS="-W -D language='en'" html
+sphinxopts="-W -D language='en'"
+if [ "${GITHUB_PR_TARGET_BRANCH}" = "8.1.x" ]; then
+  sphinxopts="-D language='en'"
+fi
+make -j4 -e SPHINXOPTS="${sphinxopts}" html
 _END_OF_DOC_
-                    
+
                     chmod 755 ${tmpfile}
                     echo "Running:"
                     cat ${tmpfile}

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -84,7 +84,7 @@ _END_OF_DOC_
                     cat ${tmpfile}
                     pipenv run ${tmpfile} || exit 1
                     rm ${tmpfile}
-                    
+
                     # If we made it here, the doc build ran and succeeded. Let's copy out the
                     # docbuild contents so it can be published.
                     export_dir="${WORKSPACE}/output/${GITHUB_PR_NUMBER}"


### PR DESCRIPTION
Exception for 8.1.x for both branch and github doc builds.