### PR TITLE
branch builds: go from hard coded other builds to a job parameter

### DIFF
--- a/jenkins/branch/branch_build.pipeline
+++ b/jenkins/branch/branch_build.pipeline
@@ -43,21 +43,23 @@ def doParallelBuilds() {
 		}
 	}
 
-	String jobstr = "osx freebsd osx-m1"
-	def extrajobs = jobstr.split(" ")
+	if (env.OTHER_BUILDS) {
+		//String jobstr = "osx freebsd osx-m1"
+		def extrajobs = env.OTHER_BUILDS.split(" ")
 
-	for (job in extrajobs) {
-		def name = job
-		def jobpath = prefix + name
-		echo "Adding ${jobpath} as ${name}"
-		if (isBuildable(jobpath)) {
-			builders[name] = {
-				stage(name) {
-					echo jobpath
-					script {
-						result = buildJob(jobpath, name)
-						if (result == 'FAILURE') {
-							error("${name} build failed")
+		for (job in extrajobs) {
+			def name = job
+			def jobpath = prefix + name
+			echo "Adding ${jobpath} as ${name}"
+			if (isBuildable(jobpath)) {
+				builders[name] = {
+					stage(name) {
+						echo jobpath
+						script {
+							result = buildJob(jobpath, name)
+							if (result == 'FAILURE') {
+								error("${name} build failed")
+							}
 						}
 					}
 				}

--- a/jenkins/branch/os_build.pipeline
+++ b/jenkins/branch/os_build.pipeline
@@ -56,7 +56,7 @@ pipeline {
 				echo 'Starting Build'
 				dir('src') {
 					sh '''
-                                        set -x
+					set -x
 					source ../ci/jenkins/bin/environment.sh
 					autoreconf -if
 					source ../ci/jenkins/bin/build.sh
@@ -70,7 +70,7 @@ pipeline {
 				echo 'Starting Tests'
 				dir('src') {
 					sh '''
-                                        set -x
+					set -x
 					source ../ci/jenkins/bin/environment.sh
 					source ../ci/jenkins/bin/regression.sh
 					'''


### PR DESCRIPTION
This changes building things like osx, freebsd, etc to be a job parameter OTHER_BUILDS instead of hard coded in the branch_builds script.