### PR TITLE
Add dependencies for building ATS with quiche

### DIFF
--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -81,3 +81,37 @@ RUN yum clean all
 RUN yum install -y ctags elfutils-libelf-devel wdiff
 COPY /install_abi_tools.sh /root/install_abi_tools.sh
 RUN bash /root/install_abi_tools.sh
+
+#-----------------------------
+# Install quiche dependencies.
+#-----------------------------
+
+RUN yum install -y cmake
+
+# Retrieve quiche
+RUN \
+  mkdir -p src && \
+  cd src && \
+  git clone --recursive https://github.com/cloudflare/quiche
+
+# Install rust/cargo.
+RUN \
+  mkdir -p src && \
+  wget https://sh.rustup.rs -O src/rustup.sh && \
+  bash src/rustup.sh -y
+
+# Build quiche.
+RUN \
+  source "/root/.cargo/env" && \
+  cd src/quiche && \
+  cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
+
+# Manually install quiche because, unfortunately, the cargo install command
+# doesn't work for quiche.
+RUN \
+  mkdir -p /opt/quiche/lib/pkgconfig && \
+  mkdir -p /opt/quiche/include && \
+  cp src/quiche/target/release/libquiche.a /opt/quiche/lib && \
+  cp src/quiche/target/release/libquiche.so /opt/quiche/lib && \
+  cp src/quiche/quiche/include/quiche.h /opt/quiche/include && \
+  cp src/quiche/target/release/quiche.pc /opt/quiche/lib/pkgconfig


### PR DESCRIPTION
This builds and installs quich in /opt/quiche so we can test building ATS using quiche.