### PR TITLE
Remove `yum update` from Dockerfiles

### DIFF
--- a/docker/alma/Dockerfile
+++ b/docker/alma/Dockerfile
@@ -2,7 +2,6 @@ FROM almalinux/almalinux:8
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -8,7 +8,6 @@ RUN \
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/centos8/Dockerfile
+++ b/docker/centos8/Dockerfile
@@ -8,7 +8,6 @@ RUN \
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:30
-RUN yum -y update; \
+RUN  \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang git sudo; \
     # Various other tools

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,6 +1,5 @@
 FROM fedora:30
-RUN  \
-    # Compilers
+RUN # Compilers \
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang git sudo; \
     # Various other tools
     git rpm-build distcc-server file wget openssl hwloc; \

--- a/docker/fedora32/Dockerfile
+++ b/docker/fedora32/Dockerfile
@@ -2,7 +2,6 @@ FROM fedora:32
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/fedora35/Dockerfile
+++ b/docker/fedora35/Dockerfile
@@ -2,7 +2,6 @@ FROM fedora:35
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/fedora36/Dockerfile
+++ b/docker/fedora36/Dockerfile
@@ -2,7 +2,6 @@ FROM fedora:36
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/fedora37/Dockerfile
+++ b/docker/fedora37/Dockerfile
@@ -2,7 +2,6 @@ FROM fedora:37
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf

--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -2,7 +2,6 @@ FROM rockylinux:8
 
 RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
 
-    yum -y update; \
     # Compilers
     yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
     # Autoconf


### PR DESCRIPTION
Calling `yum update` updates the OS to a later release. We should remove the calls from the Dockerfiles so we don't accidentally run with a later release.