### PR TITLE
Removing call to --enable-luajit in jenkins jobs

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -81,7 +81,7 @@ pipeline {
 						# (default user umask may change and make these unreadable)
 						sudo chmod -R o+r .
 						autoreconf -fiv
-						./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
+						./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats --enable-werror --enable-debug --enable-wccp --enable-ccache
 						make -j4
 						make install
 						'''

--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -49,7 +49,7 @@ pipeline {
                         set -e
                         source /opt/rh/gcc-toolset-9/enable
                         autoreconf -fiv
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-luajit --enable-ccache
+                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-ccache
                         make -j4 V=1 Q=
                         make -j 2 check VERBOSE=Y V=1
                         make install

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -72,7 +72,7 @@ pipeline {
                         fi
 
                         # Remove the --with-openssl argument when we support OpenSSL 3.x.
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-luajit --enable-ccache
+                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-ccache
                         make -j4 V=1 Q=
                         make -j 2 check VERBOSE=Y V=1
                         make install

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -49,7 +49,7 @@ pipeline {
                         set -e
                         source /opt/rh/gcc-toolset-11/enable
                         autoreconf -fiv
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-luajit --enable-ccache
+                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-ccache
                         make -j4 V=1 Q=
                         make -j 2 check VERBOSE=Y V=1
                         make install


### PR DESCRIPTION
Some scripts still --enable-luajit...I didn't remove it from the branch pipelines in case it was still helpful there, and some shell scripts still reference it in case that's helpful for the same reason.