### PR TITLE
Change Rocky build to use the quiche build

### DIFF
--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -49,7 +49,14 @@ pipeline {
                         set -e
                         source /opt/rh/gcc-toolset-11/enable
                         autoreconf -fiv
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-ccache
+                        ./configure \
+                          --with-quiche=/opt/quiche \
+                          --enable-experimental-plugins \
+                          --enable-example-plugins \
+                          --prefix=/tmp/ats/ \
+                          --enable-werror \
+                          --enable-debug \
+                          --enable-ccache
                         make -j4 V=1 Q=
                         make -j 2 check VERBOSE=Y V=1
                         make install


### PR DESCRIPTION
The real change here, other than whitespace, is:

`--with-openssl=/opt/openssl-quic` -> `--with-quiche=/opt/quiche`