### PR TITLE
Make quiche regression tests use -R 1

### DIFF
--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -95,7 +95,7 @@ pipeline {
 						set -x
 						source /opt/rh/gcc-toolset-11/enable
 						make -j4 V=1 Q= check
-						/tmp/ats/bin/traffic_server -K -k -R 3
+						/tmp/ats/bin/traffic_server -K -k -R 1
 						'''
 				}
 			}


### PR DESCRIPTION
I initially configured the quiche branch job to use `-R 3` for the
regression tests while all other jenkins scripts use `-R 1`. I thought
we might fix the `-R 3` but that hasn't happened yet. The issue is
recorded here:

https://github.com/apache/trafficserver/issues/9576

Once that is fixed, we should update some CI jobs to use `-R 3` again.
In the meantime, we should make the quiche branch job use `-R 1` to
match the other jobs and catch if something breaks the quiche builds.