### PR TITLE
Update to go-httpbin v2.6.0

### DIFF
--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -122,7 +122,7 @@ RUN \
   cp /root/go/bin/h2spec /usr/local/go/bin/
 
 RUN \
-  /usr/local/go/bin/go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2.5.6; \
+  /usr/local/go/bin/go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2.6.0; \
   cp /root/go/bin/go-httpbin /usr/local/go/bin/
 
 # BoringSSL has no releases or tags. For Docker image reproducibilty, we pin to


### PR DESCRIPTION
This has a fix for /bytes/0 to actually return 0 bytes.