### PR TITLE
Ensuring /usr/local/go/bin in PATH for autests

### DIFF
--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -103,6 +103,7 @@ pipeline {
 						# We want to pick up the OpenSSL-QUIC version of curl in /opt/bin.
 						# The HTTP/3 AuTests depend upon this, so update the PATH accordingly.
 						export PATH=/opt/bin:${PATH}
+						export PATH=/usr/local/go/bin:${PATH}
 
 						mkdir -p ${WORKSPACE}/output/${GITHUB_BRANCH}
 

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -137,6 +137,7 @@ pipeline {
 						# We want to pick up the OpenSSL-QUIC version of curl in /opt/bin.
 						# The HTTP/3 AuTests depend upon this, so update the PATH accordingly.
 						export PATH=/opt/bin:${PATH}
+						export PATH=/usr/local/go/bin:${PATH}
 
 						./autest.sh --ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox
 						'''

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -111,6 +111,7 @@ pipeline {
 						set +e
 
 						export PATH=/opt/bin:${PATH}
+						export PATH=/usr/local/go/bin:${PATH}
 
 						export_dir="${WORKSPACE}/output/${GITHUB_PR_BRANCH}"
 						mkdir -p ${export_dir}

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -97,6 +97,7 @@ pipeline {
 						# We want to pick up the OpenSSL-QUIC version of curl in /opt/bin.
 						# The HTTP/3 AuTests depend upon this, so update the PATH accordingly.
 						export PATH=/opt/bin:${PATH}
+						export PATH=/usr/local/go/bin:${PATH}
 						
 						export_dir="${WORKSPACE}/output/${GITHUB_PR_NUMBER}"
 						mkdir -p ${export_dir}


### PR DESCRIPTION
Ensure that the pipelines running autest.sh have /usr/local/go/bin in their PATH so it can find go-httpbin and h2spec.