### PR TITLE
PR cmake.pipeline: put /opt/bin in the path

### DIFF
--- a/jenkins/github/cmake.pipeline
+++ b/jenkins/github/cmake.pipeline
@@ -60,6 +60,8 @@ pipeline {
 
 
                         source /opt/rh/gcc-toolset-11/enable
+                        export PATH=/opt/bin:${PATH}
+
                         mkdir cmake-build-release
                         cd cmake-build-release
                         cmake -DCMAKE_BUILD_TYPE:STRING=Release -DOPENSSL_ROOT_DIR=/opt/openssl-quic ..


### PR DESCRIPTION
I installed a new version of cmake for the work Chris McFarlen is doing. Putting /opt/bin in the PATH is in the /etc/profile.d/opt_bin.sh, but that doesn't work for jenkins for some reason. Explicitly adding it to the PATH for the pipeline script.