### PR TITLE
/opt/boringssl/lib64 to LD_LIBRARY_PATH

### DIFF
--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -69,6 +69,10 @@ pipeline {
 
 					source /opt/rh/gcc-toolset-11/enable
 
+					# We'll need this until Damian's quiche patch lands which updates rpath:
+					# https://github.com/cloudflare/quiche/pull/1508
+					export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
+
 					# Change permissions so that all files are readable
 					# (default user umask may change and make these unreadable)
 					sudo chmod -R o+r .

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -48,6 +48,11 @@ pipeline {
                         set -x
                         set -e
                         source /opt/rh/gcc-toolset-11/enable
+
+                        # We'll need this until Damian's quiche patch lands which updates rpath:
+                        # https://github.com/cloudflare/quiche/pull/1508
+                        export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
+
                         autoreconf -fiv
                         ./configure \
                           --with-quiche=/opt/quiche \


### PR DESCRIPTION
This is needed for now because the quiche rpath doesn't contain an update for the location of the boringssl location. This should fix some issues with quiche builds.