### PR TITLE
For old git in centos:7: --no-patch -> -s

### DIFF
--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -35,7 +35,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url, refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
-                    sh 'git show -n 10 --decorate --graph --oneline --no-patch'
+                    sh 'git show -n 10 --decorate --graph --oneline -s'
                 }
                 echo 'Finished Cloning'
             }


### PR DESCRIPTION
The old git in centos:7 doesn't recognize --no-patch