### PR TITLE
Remove the build_h3_tools dir

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -57,7 +57,8 @@ RUN \
   source /opt/rh/devtoolset-11/enable; \
   source /opt/rh/rh-python38/enable; \
   export PATH=/opt/bin:${PATH}; \
-  bash ${h3_tools_dir}/build_h3_tools.sh
+  bash ${h3_tools_dir}/build_h3_tools.sh; \
+  rm -rf ${h3_tools_dir} /root/.rustup
 
 WORKDIR /root
 

--- a/docker/fedora38/Dockerfile
+++ b/docker/fedora38/Dockerfile
@@ -35,7 +35,9 @@ RUN mkdir -p ${h3_tools_dir}
 WORKDIR ${h3_tools_dir}
 COPY /build_h3_tools.sh ${h3_tools_dir}/build_h3_tools.sh
 # This will install OpenSSL QUIC and related tools in /opt.
-RUN bash ${h3_tools_dir}/build_h3_tools.sh
+RUN \
+  bash ${h3_tools_dir}/build_h3_tools.sh; \
+  rm -rf ${h3_tools_dir} /root/.rustup
 WORKDIR /root
 
 # Make sure we pick up this built version of curl, which is in /opt/bin.

--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -47,7 +47,9 @@ RUN mkdir -p ${h3_tools_dir}
 WORKDIR ${h3_tools_dir}
 COPY /build_h3_tools.sh ${h3_tools_dir}/build_h3_tools.sh
 # This will install OpenSSL QUIC and related tools in /opt.
-RUN bash ${h3_tools_dir}/build_h3_tools.sh
+RUN \
+  bash ${h3_tools_dir}/build_h3_tools.sh; \
+  rm -rf ${h3_tools_dir} /root/.rustup
 WORKDIR /root
 
 # Install some of our needed go applications.

--- a/docker/rockylinux9/Dockerfile
+++ b/docker/rockylinux9/Dockerfile
@@ -40,7 +40,7 @@ RUN dnf -y install libev-devel jemalloc-devel libxml2-devel \
 #WORKDIR ${h3_tools_dir}
 #COPY /build_h3_tools.sh ${h3_tools_dir}/build_h3_tools.sh
 # This will install OpenSSL QUIC and related tools in /opt.
-#RUN bash ${h3_tools_dir}/build_h3_tools.sh
+#RUN bash ${h3_tools_dir}/build_h3_tools.sh; rm -rf ${h3_tools_dir} /root/.rustup
 WORKDIR /root
 
 # Make sure we pick up this built version of curl, which is in /opt/bin.


### PR DESCRIPTION
This takes up a lot of space, especially now that boring is in there.

This cuts the rockylinux:8 build down to 3.5 GB from 7.5 GB.