### PR TITLE
Have fedora builds test with system openssl 3.x

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -53,10 +53,9 @@ pipeline {
                         export CXXSTD=20
 
                         autoreconf -fiv
-                        # Remove the --with-openssl argument when we support OpenSSL 3.x.
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-ccache
+                        ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-ccache
                         make -j4 V=1 Q=
-                        make -j 2 check VERBOSE=Y V=1
+                        make -j4 check VERBOSE=Y V=1
                         make install
                         /tmp/ats/bin/traffic_server -K -k -R 1
                     '''


### PR DESCRIPTION
We now support openssl 3.x. We might as well test it with our PR builds. fedora:38 ships with openssl 3.x, so converting that to use the system ssl.