### PR TITLE
fedora:38 Dockerfile to use heredoc

### DIFF
--- a/docker/fedora38/Dockerfile
+++ b/docker/fedora38/Dockerfile
@@ -1,85 +1,117 @@
 FROM fedora:38
 
-RUN yum -y install epel-release dnf-plugins-core; yum config-manager --set-enabled powertools; yum repolist; \
+#-------------------------------------------------------------------------------
+# Install the various system packages we use.
+#-------------------------------------------------------------------------------
+RUN <<EOF
+  set -e
 
-    yum -y update; \
-    # Compilers
-    yum -y install ccache make pkgconfig bison flex gcc-c++ clang \
-    # Autoconf
+  yum -y install dnf-plugins-core
+  yum repolist
+  yum -y update
+
+  # Build tools.
+  yum -y install \
+    ccache make pkgconfig bison flex gcc-c++ clang \
     autoconf automake libtool \
-    # Various other tools
-    sudo git rpm-build distcc-server file wget openssl hwloc nghttp2 libnghttp2-devel; \
-    # Devel packages that ATS needs
-    yum -y install openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
+    cmake ninja-build
+
+  # Various other tools
+  yum -y install \
+    sudo git rpm-build distcc-server file wget openssl hwloc \
+    nghttp2 libnghttp2-devel
+
+  # Devel packages that ATS needs
+  yum -y install \
+    openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
     xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
     ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
-    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI curl tcl-devel java; \
-    # autest stuff
-    yum -y install python3 httpd-tools procps-ng nmap-ncat python3-pip \
-    python3-gunicorn python3-requests python3-devel python3-psutil telnet;
+    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI curl tcl-devel java
+
+  # autest stuff
+  yum -y install \
+    python3 httpd-tools procps-ng nmap-ncat python3-pip \
+    python3-gunicorn python3-requests python3-devel python3-psutil telnet
+EOF
+
+#-------------------------------------------------------------------------------
+# Install some custom build tools.
+#-------------------------------------------------------------------------------
+
+WORKDIR /root
+
+# We put our custom packages in /opt.
+RUN <<EOS
+  set -e
+  mkdir -p /opt/bin
+  chmod 755 /opt/bin
+  echo 'PATH=/opt/bin:$PATH' | tee -a /etc/profile.d/opt_bin.sh
+EOS
+ARG PATH=/opt/bin:$PATH
 
 # This currently fails with latest fedora:38. Presumably the stock pip is
 # recent enough, so this shouldn't be a big deal.
 # RUN pip3 install --upgrade pip
 RUN pip3 install pipenv httpbin
 
-# Install openssl-quic
+#-------------------------------------------------------------------------------
+# Install the HTTP/3 build tools, including openssl-quic.
+#-------------------------------------------------------------------------------
 RUN yum -y install libev-devel jemalloc-devel libxml2-devel \
     c-ares-devel libevent-devel jansson-devel zlib-devel systemd-devel \
-    perl-FindBin cmake cargo
+    perl-FindBin cargo
 
 # go will be installed by build_h3_tools.
 RUN yum remove -y golang
 ARG h3_tools_dir=/root/build_h3_tools
 RUN mkdir -p ${h3_tools_dir}
-WORKDIR ${h3_tools_dir}
 COPY /build_h3_tools.sh ${h3_tools_dir}/build_h3_tools.sh
 # This will install OpenSSL QUIC and related tools in /opt.
-RUN \
+RUN <<EOS
+  set -e
+  cd ${h3_tools_dir}
   bash ${h3_tools_dir}/build_h3_tools.sh; \
   rm -rf ${h3_tools_dir} /root/.rustup
-WORKDIR /root
+EOS
 
-# Make sure we pick up this built version of curl, which is in /opt/bin.
-RUN echo 'PATH=/opt/bin:$PATH' | tee -a /etc/profile.d/curl_http3.sh
 
-# Install some of our needed go applications.
-RUN echo 'export PATH=$PATH:/opt/go/bin' | tee -a /etc/profile.d/go.sh
-RUN echo 'export GOBIN=/opt/go/bin' | tee -a /etc/profile.d/go.sh
-RUN \
-  /opt/go/bin/go install github.com/summerwind/h2spec/cmd/h2spec@latest; \
+#-------------------------------------------------------------------------------
+# Various CI Job and Test Requirements.
+#-------------------------------------------------------------------------------
+
+# Autests require some go applications.
+RUN <<EOS
+  set -e
+  echo 'export PATH=$PATH:/opt/go/bin' | tee -a /etc/profile.d/go.sh
+  echo 'export GOBIN=/opt/go/bin' | tee -a /etc/profile.d/go.sh
+
+  /opt/go/bin/go install github.com/summerwind/h2spec/cmd/h2spec@latest
   cp /root/go/bin/h2spec /opt/go/bin/
 
-RUN \
-  /opt/go/bin/go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2.6.0; \
+  /opt/go/bin/go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2.6.0
   cp /root/go/bin/go-httpbin /opt/go/bin/
+EOS
 
 # Add the CI's test user. N.B: 1200 is the uid that our jenkins user is
 # configured with, so that has to be used. Otherwise there will be permissions
 # issues.
 ARG username=jenkins
 ARG uid=1200
-RUN useradd \
+RUN <<EOS
+  set -e
+  useradd \
     --home-dir /home/${username} \
     --groups users,wheel \
     --uid ${uid} \
     --shell /bin/bash \
     --create-home \
     ${username}
-RUN echo "${username} ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN chown -R ${username} /home/${username}
+  echo "${username} ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+  chown -R ${username} /home/${username}
+EOS
 
-# Install lcov requirements.
-RUN yum install -y perl-IO-Compress
-ARG lcov_build_dir=/var/tmp/lcov_build_dir
-RUN mkdir -p ${lcov_build_dir}
-WORKDIR ${lcov_build_dir}
-RUN git clone https://github.com/linux-test-project/lcov.git; \
-    cd lcov; \
-    # v1.15 is required for g++ version 9 compiled files.
-    git checkout v1.15; \
-    make install
-WORKDIR /root
-RUN rm -rf ${lcov_build_dir}
+# Install lcov
+RUN yum install -y lcov
+
 # Keep this at the end to clean up the yum cache.
 RUN yum clean all

--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -127,6 +127,7 @@ RUN update-crypto-policies --set LEGACY
 ARG username=jenkins
 ARG uid=1200
 RUN <<EOS
+  set -e
   useradd \
     --home-dir /home/${username} \
     --groups users,wheel \
@@ -142,17 +143,17 @@ EOS
 RUN yum install -y perl-IO-Compress
 ARG lcov_build_dir=/var/tmp/lcov_build_dir
 RUN mkdir -p ${lcov_build_dir}
-WORKDIR ${lcov_build_dir}
 RUN <<EOS
   set -e
+  cd ${lcov_build_dir}
   git clone https://github.com/linux-test-project/lcov.git
   cd lcov
   # v1.15 is required for g++ version 9 compiled files.
   git checkout v1.15
   make install
+  cd /root
+  rm -rf ${lcov_build_dir}
 EOS
-WORKDIR /root
-RUN rm -rf ${lcov_build_dir}
 
 # Install ABI checking tools.
 RUN yum install -y ctags elfutils-libelf-devel wdiff


### PR DESCRIPTION
Also, the system lcov is 1.15, so I think installing from yum should be fine.

This applies the same changes from rockylinux (use heredocs) to fedora:38 Dockerfile:
https://github.com/apache/trafficserver-ci/pull/176