### PR TITLE
build_h3_tools: account for aarch64

### DIFF
--- a/docker/fedora38/build_h3_tools.sh
+++ b/docker/fedora38/build_h3_tools.sh
@@ -98,7 +98,7 @@ echo "Building boringssl..."
 # We need this go version.
 mkdir -p ${BASE}/go
 
-if [ `uname -m` = "arm64" ]; then
+if [ `uname -m` = "arm64" -o `uname -m` = "aarch64" ]; then
     ARCH="arm64"
 else
     ARCH="amd64"

--- a/docker/rockylinux8/build_h3_tools.sh
+++ b/docker/rockylinux8/build_h3_tools.sh
@@ -98,7 +98,7 @@ echo "Building boringssl..."
 # We need this go version.
 mkdir -p ${BASE}/go
 
-if [ `uname -m` = "arm64" ]; then
+if [ `uname -m` = "arm64" -o `uname -m` = "aarch64" ]; then
     ARCH="arm64"
 else
     ARCH="amd64"


### PR DESCRIPTION
In build_h3_tools, support Linux arm64 whose uname -m is aarch64. This is already in ATS tools/build_h3_tools.sh