### PR TITLE
latest openssl-quic library perl packages requirements

### DIFF
--- a/docker/fedora38/Dockerfile
+++ b/docker/fedora38/Dockerfile
@@ -26,7 +26,8 @@ RUN <<EOF
     openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
     xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
     ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
-    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI curl tcl-devel java
+    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI perl-IPC-Cmd perl-Pod-Html \
+    curl tcl-devel java
 
   # autest stuff
   yum -y install \


### PR DESCRIPTION
The latest openssl-3.0.9+quic requires a couple other perl-* packages to be installed in order to build.