### PR TITLE
Update build_h3_tools for fedora:38 to Openssl 3.0

### DIFF
--- a/docker/fedora38/build_h3_tools.sh
+++ b/docker/fedora38/build_h3_tools.sh
@@ -37,7 +37,7 @@ set -e
 #   that it later removes.
 
 # Update this as the draft we support updates.
-OPENSSL_BRANCH=${OPENSSL_BRANCH:-"OpenSSL_1_1_1u+quic"}
+OPENSSL_BRANCH=${OPENSSL_BRANCH:-"openssl-3.0.9+quic"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory


### PR DESCRIPTION
This is what the apache/trafficserver/tools/build_h3_tools.sh file now uses.