### PR TITLE
change to debian 12 for github pr builds

### DIFF
--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ci.trafficserver.apache.org/ats/debian:10'
+            image 'ci.trafficserver.apache.org/ats/debian:12'
             registryUrl 'https://ci.trafficserver.apache.org/'
             label 'docker'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'


### PR DESCRIPTION
Change from sunlit debian 10 to debian 12 for github pr builds.