### PR TITLE
Add ASan build (on ubuntu)

### DIFF
--- a/jenkins/github/asan.pipeline
+++ b/jenkins/github/asan.pipeline
@@ -1,0 +1,75 @@
+pipeline {
+    agent {
+        docker {
+            image 'ci.trafficserver.apache.org/ats/ubuntu:23.04'
+            registryUrl 'https://ci.trafficserver.apache.org/'
+            label 'docker'
+            args '-v ${HOME}/ccache:/tmp/ccache:rw'
+        }
+    }
+    environment {
+        CCACHE_DIR = "/tmp/ccache"
+        CCACHE_BASEDIR = "${WORKSPACE}"
+    }
+    stages {
+        stage('Clone') {
+            steps {
+                dir('src') {
+                    echo "${sha1}"
+                    checkout([$class: 'GitSCM',
+                        branches: [[name: sha1]],
+                        extensions: [
+                            // We have to set an idenity for the merge step because Git requires
+                            // the user.name and user.email to be set to do a merge.
+                            [$class: "UserIdentity",
+                                name: "ATS CI User",
+                                email: "noreply@trafficserver.apache.org"
+                            ],
+                            [$class: "PreBuildMerge",
+                                options: [
+                                    mergeTarget: "${GITHUB_PR_TARGET_BRANCH}",
+                                    fastForwardMode: "NO_FF",
+                                    mergeRemote: "origin",
+                                    mergeStrategy: "DEFAULT"
+                                ]
+                            ],
+                        ],
+                        userRemoteConfigs: [[url: github_url, refspec: '+refs/pull/*:refs/remotes/origin/pr/*']]])
+                    sh 'git show -n 10 --decorate --graph --oneline --no-patch'
+                }
+                echo 'Finished Cloning'
+            }
+        }
+        stage('Build') {
+            steps {
+                echo 'Starting build'
+                dir('src') {
+                    sh '''#!/bin/bash
+
+                        set -x
+                        set -e
+
+                        # We don't use c++20 features yet, but we want to make
+                        # sure we can build with the flag set.
+                        export CXXSTD=20
+
+                        autoreconf -fiv
+                        mkdir out_of_source_build_dir
+                        cd out_of_source_build_dir
+                        CC="clang" CXX="clang++" ../configure --enable-experimental-plugins --enable-example-plugins --enable-expensive-tests --prefix=/tmp/ats/ --enable-werror --enable-ccache --enable-asan
+                        make -j4 V=1 Q=
+                        make -j4 check VERBOSE=Y V=1
+                        make install
+                        /tmp/ats/bin/traffic_server -K -k -R 1
+                    '''
+                }
+            }
+        }
+    }
+
+    post {
+        cleanup {
+            cleanWs()
+        }
+    }
+}

--- a/jenkins/github/toplevel.pipeline
+++ b/jenkins/github/toplevel.pipeline
@@ -2,7 +2,7 @@ TOP_JOB_DESC = "Builds:\\n"
 
 String buildJob(String ghcontext, String jobName, String shard='') {
 		setGitHubPullRequestStatus(context: ghcontext, message: 'Building', state: 'PENDING')
-		
+
 	if (currentBuild.description == null) {
 		currentBuild.description = "Builds:<br>"
 	}
@@ -40,7 +40,7 @@ String buildJob(String ghcontext, String jobName, String shard='') {
 
 pipeline {
 	agent none
-	
+
 	stages {
 		stage('Quick Checks') {
 			parallel {
@@ -92,7 +92,7 @@ pipeline {
 							}
 						}
 					}
-				}                
+				}
 			}
 		}
 
@@ -120,7 +120,7 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*fedora.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('Fedora', 'Github_Builds/fedora')
@@ -136,7 +136,7 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*debian.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('Debian', 'Github_Builds/debian')
@@ -154,7 +154,7 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*rocky.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('Rocky', 'Github_Builds/rocky')
@@ -188,7 +188,7 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*cmake.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('CMake', 'Github_Builds/cmake')
@@ -198,14 +198,14 @@ pipeline {
 						}
 					}
 				}
-				
+
 				stage('OSX Build') {
 					when {
 						anyOf {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*osx.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('OSX', 'Github_Builds/osx')
@@ -222,12 +222,29 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*freebsd.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('FreeBSD', 'Github_Builds/freebsd')
 							if (result == 'FAILURE') {
 								error('FreeBSD build failed')
+							}
+						}
+					}
+				}
+
+				stage('ASan') {
+					when {
+						anyOf {
+							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
+							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*asan.*/ }
+						}
+					}
+					steps {
+						script {
+							result = buildJob('ASan', 'Github_Builds/asan')
+							if (result == 'FAILURE') {
+								error('ASan failed')
 							}
 						}
 					}
@@ -239,7 +256,7 @@ pipeline {
 							environment name: 'GITHUB_PR_COMMENT_BODY_MATCH', value: ''
 							expression { GITHUB_PR_COMMENT_BODY_MATCH ==~ /.*clang-analyzer.*/ }
 						}
-					}                    
+					}
 					steps {
 						script {
 							result = buildJob('Clang-Analyzer', 'Github_Builds/clang-analyzer')
@@ -249,6 +266,7 @@ pipeline {
 						}
 					}
 				}
+
 				stage('AuTest') {
 					when {
 						anyOf {


### PR DESCRIPTION
Add `--enable-asan` option build. Base settings are copied from "ubuntu" build.

# TODO

This requires below PRs on apache/trafficserver repo

- [x] https://github.com/apache/trafficserver/pull/9998
- [x] https://github.com/apache/trafficserver/pull/10038
- [x] https://github.com/apache/trafficserver/pull/10064
- [x] https://github.com/apache/trafficserver/pull/10072
- [x] https://github.com/apache/trafficserver/pull/10161
- [x] https://github.com/apache/trafficserver/pull/10178
- [ ] https://github.com/apache/trafficserver/issues/10295