### PR TITLE
cmake: -DCMAKE_COMPILE_WARNING_AS_ERROR=ON

### DIFF
--- a/jenkins/bin/cmake.sh
+++ b/jenkins/bin/cmake.sh
@@ -24,7 +24,7 @@ cd "${WORKSPACE}/src"
 
 mkdir cmake-build-release
 cd cmake-build-release
-cmake -GNinja -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DCMAKE_INSTALL_PREFIX=/tmp/ats ..
+cmake -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DCMAKE_INSTALL_PREFIX=/tmp/ats ..
 cmake --build . -j4 -v
 cmake --install .
 ctest -j4 --output-on-failure --no-compress-output -T Test

--- a/jenkins/github/cmake.pipeline
+++ b/jenkins/github/cmake.pipeline
@@ -61,7 +61,7 @@ pipeline {
 
                         export PATH=/opt/bin:${PATH}
 
-                        cmake -B cmake-build-release -GNinja -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DCMAKE_INSTALL_PREFIX=/tmp/ats
+                        cmake -B cmake-build-release -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DCMAKE_INSTALL_PREFIX=/tmp/ats
                         cmake --build cmake-build-release -j4 -v
                         cmake --install cmake-build-release
                         pushd cmake-build-release
@@ -69,7 +69,7 @@ pipeline {
                         /tmp/ats/bin/traffic_server -K -k -R 1
                         popd
 
-                        cmake -B cmake-build-quiche -GNinja -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
+                        cmake -B cmake-build-quiche -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
                         cmake --build cmake-build-quiche -j4 -v
                         cmake --install cmake-build-quiche
                         pushd cmake-build-quiche


### PR DESCRIPTION
Treat warnings as errors in CI.