### PR TITLE
rockylinux:8 Dockerfile: add perl modules

### DIFF
--- a/docker/rockylinux8/Dockerfile
+++ b/docker/rockylinux8/Dockerfile
@@ -27,7 +27,8 @@ RUN <<EOF
     openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
     xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
     ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
-    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI curl tcl-devel java
+    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI perl-IPC-Cmd perl-Pod-Html \
+    curl tcl-devel java
 
   # autest stuff
   yum -y install \


### PR DESCRIPTION
Adding rockylinux:8 perl module install list for the latest build_h3_tools.sh.