### PR TITLE
Remove the setting of LD_LIBRARY_PATH for boring

### DIFF
--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -70,10 +70,6 @@ pipeline {
 
 					source /opt/rh/gcc-toolset-11/enable
 
-					# We'll need this until Damian's quiche patch lands which updates rpath:
-					# https://github.com/cloudflare/quiche/pull/1508
-					export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
-
 					# Change permissions so that all files are readable
 					# (default user umask may change and make these unreadable)
 					sudo chmod -R o+r .
@@ -101,7 +97,6 @@ pipeline {
 						set -x
 						set -e
 						source /opt/rh/gcc-toolset-11/enable
-						export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
 						make -j4 V=1 Q= check
 						/tmp/ats/bin/traffic_server -K -k -R 1
 						'''
@@ -119,10 +114,6 @@ pipeline {
 
 						export PATH=/opt/bin:${PATH}
 						export PATH=/opt/go/bin:${PATH}
-
-						# We'll need this until Damian's quiche patch lands which updates rpath:
-						# https://github.com/cloudflare/quiche/pull/1508
-						export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
 
 						export_dir="${WORKSPACE}/output/${GITHUB_PR_BRANCH}"
 						mkdir -p ${export_dir}

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -48,11 +48,6 @@ pipeline {
                         set -x
                         set -e
                         source /opt/rh/gcc-toolset-11/enable
-
-                        # We'll need this until Damian's quiche patch lands which updates rpath:
-                        # https://github.com/cloudflare/quiche/pull/1508
-                        export LD_LIBRARY_PATH=/opt/boringssl/lib64:${LD_LIBRARY_PATH}
-
                         autoreconf -fiv
                         ./configure \
                           --with-quiche=/opt/quiche \


### PR DESCRIPTION
Now that Damian's rpath fix for https://github.com/cloudflare/quiche/pull/1508 has landed, we no longer need to explicitly set LD_LIBRARY_PATH for our quiche builds.