### PR TITLE
Enable old releases to use older clang-analyzer images

### DIFF
--- a/jenkins/bin/clang-analyzer.sh
+++ b/jenkins/bin/clang-analyzer.sh
@@ -18,20 +18,23 @@
 
 set -x
 
-test -z "${WORKSPACE}" && WORKSPACE=".."
+WORKSPACE=${WORKSPACE:-..}
+GITHUB_BRANCH=${GITHUB_BRANCH:-master}
+CA_VERSION=${CA_VERSION:-14}
+
 mkdir -p ${WORKSPACE}/output/${GITHUB_BRANCH}
 
 grep -q 80010 configure.ac && echo "8.1.x branch detected, stop here!" && exit 0
 
 autoreconf -fiv
-scan-build-14 --keep-cc \
+scan-build-${CA_VERSION} --keep-cc \
   ./configure --enable-experimental-plugins --with-luajit
 
 # build things like yamlcpp without the analyzer 
 make -j4 -C lib all-local V=1 Q=
 rptdir="${WORKSPACE}/output/${GITHUB_BRANCH}"
 
-scan-build-14 --keep-cc \
+scan-build-${CA_VERSION} --keep-cc \
   -enable-checker alpha.unix.cstring.BufferOverlap \
   -enable-checker alpha.core.BoolAssignment \
   -enable-checker alpha.core.CastSize \

--- a/jenkins/bin/clang-analyzer.sh
+++ b/jenkins/bin/clang-analyzer.sh
@@ -18,23 +18,23 @@
 
 set -x
 
+grep -q 80010 configure.ac && echo "8.1.x branch detected, stop here!" && exit 0
+
 WORKSPACE=${WORKSPACE:-..}
 GITHUB_BRANCH=${GITHUB_BRANCH:-master}
-CA_VERSION=${CA_VERSION:-14}
+SCAN_BUILD=$(ls /usr/bin/scan-build* | grep -v py | tail -n 1)
 
 mkdir -p ${WORKSPACE}/output/${GITHUB_BRANCH}
 
-grep -q 80010 configure.ac && echo "8.1.x branch detected, stop here!" && exit 0
-
 autoreconf -fiv
-scan-build-${CA_VERSION} --keep-cc \
+${SCAN_BUILD} --keep-cc \
   ./configure --enable-experimental-plugins --with-luajit
 
 # build things like yamlcpp without the analyzer 
 make -j4 -C lib all-local V=1 Q=
 rptdir="${WORKSPACE}/output/${GITHUB_BRANCH}"
 
-scan-build-${CA_VERSION} --keep-cc \
+${SCAN_BUILD} --keep-cc \
   -enable-checker alpha.unix.cstring.BufferOverlap \
   -enable-checker alpha.core.BoolAssignment \
   -enable-checker alpha.core.CastSize \

--- a/jenkins/branch/clang_analyzer.pipeline
+++ b/jenkins/branch/clang_analyzer.pipeline
@@ -1,8 +1,30 @@
+def getDistroName() {
+  if (! env.DISTRO) {
+		return "ubuntu:22.04"
+	} else {
+		return env.DISTRO
+	}
+}
+
+def getCaVersion() {
+	if (! env.CA_VERSION) {
+		return "14"
+	} else {
+		return env.CA_VERSION
+	}
+}
+
 pipeline {
+
+  environment {
+	  CA_DISTRO = getDistroName()
+		CA_VERSION = getCaVersion()
+	}
+
 	agent {
 		docker {
 			registryUrl 'https://ci.trafficserver.apache.org/'
-			image 'ci.trafficserver.apache.org/ats/ubuntu:22.04'
+			image 'ci.trafficserver.apache.org/ats/' + env.CA_DISTRO
 			args '-v /home/jenkins/clang-analyzer:/tmp/clang-analyzer:rw --network=host'
 			label 'branch'
 		}
@@ -59,6 +81,7 @@ pipeline {
 			steps {
 				echo 'Starting build'
 				dir('src') {
+					// Script reads CA_VER environment ariable
 					sh 'source ../ci/jenkins/bin/clang-analyzer.sh'
 				}
 			}

--- a/jenkins/branch/clang_analyzer.pipeline
+++ b/jenkins/branch/clang_analyzer.pipeline
@@ -61,9 +61,6 @@ pipeline {
 				echo 'Starting build'
 				dir('src') {
 					script {
-						if (! env.CA_VERSION) {
-							env.CA_VERSION = "14"
-						}
 						sh 'source ../ci/jenkins/bin/clang-analyzer.sh'
 					}
 				}

--- a/jenkins/branch/clang_analyzer.pipeline
+++ b/jenkins/branch/clang_analyzer.pipeline
@@ -1,30 +1,9 @@
-def getDistroName() {
-  if (! env.DISTRO) {
-		return "ubuntu:22.04"
-	} else {
-		return env.DISTRO
-	}
-}
-
-def getCaVersion() {
-	if (! env.CA_VERSION) {
-		return "14"
-	} else {
-		return env.CA_VERSION
-	}
-}
-
 pipeline {
-
-  environment {
-	  CA_DISTRO = getDistroName()
-		CA_VERSION = getCaVersion()
-	}
 
 	agent {
 		docker {
 			registryUrl 'https://ci.trafficserver.apache.org/'
-			image 'ci.trafficserver.apache.org/ats/' + env.CA_DISTRO
+			image 'ci.trafficserver.apache.org/ats/' + (env.DISTRO ? env.DISTRO : "ubuntu:22.04")
 			args '-v /home/jenkins/clang-analyzer:/tmp/clang-analyzer:rw --network=host'
 			label 'branch'
 		}
@@ -81,8 +60,12 @@ pipeline {
 			steps {
 				echo 'Starting build'
 				dir('src') {
-					// Script reads CA_VER environment ariable
-					sh 'source ../ci/jenkins/bin/clang-analyzer.sh'
+					script {
+						if (! env.CA_VERSION) {
+							env.CA_VERSION = "14"
+						}
+						sh 'source ../ci/jenkins/bin/clang-analyzer.sh'
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This allows the DISTRO to be overridden.  Currently the pipeline has hard coded the latest and greatest distro set to ubuntu 22.04.
the clang-analyzer.sh will look for the scan-build executable via:
SCAN_BUILD=$(ls /usr/bin/scan-build* | grep -v py | tail -n 1)
