### PR TITLE
rocky ci: Use Make instead of ninja

### DIFF
--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -71,7 +71,7 @@ pipeline {
                             make install
                             /tmp/ats/bin/traffic_server -K -k -R 1
                         else
-                            cmake -B cmake-build-quiche -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
+                            cmake -B cmake-build-quiche -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
                             cmake --build cmake-build-quiche -j4 -v
                             cmake --install cmake-build-quiche
                             pushd cmake-build-quiche


### PR DESCRIPTION
Our rockylinux:8 image doesn't have ninja, so revert to the default make system (Make).