### PR TITLE
fedora:39 hacks to finish build the image

### DIFF
--- a/docker/fedora39/Dockerfile
+++ b/docker/fedora39/Dockerfile
@@ -6,9 +6,10 @@ FROM fedora:39
 RUN <<EOF
   set -e
 
-  dnf -y install dnf-plugins-core
-  dnf repolist
-  dnf -y update
+  # TODO: Add these back in when fedora:39 hacks aren't needed anymore.
+  #dnf -y install dnf-plugins-core
+  #dnf repolist
+  #dnf -y update
 
   # Build tools.
   dnf -y install \
@@ -49,11 +50,6 @@ RUN <<EOF
   echo 'PATH=/opt/bin:$PATH' | tee -a /etc/profile.d/opt_bin.sh
 EOF
 ARG PATH=/opt/bin:$PATH
-
-# This currently fails with latest fedora:38. Presumably the stock pip is
-# recent enough, so this shouldn't be a big deal.
-# RUN pip3 install --upgrade pip
-RUN pip3 install pipenv httpbin
 
 #-------------------------------------------------------------------------------
 # Install the HTTP/3 build tools, including openssl-quic.

--- a/docker/fedora39/build_h3_tools.sh
+++ b/docker/fedora39/build_h3_tools.sh
@@ -128,10 +128,14 @@ fi
 cd boringssl
 mkdir -p build
 cd build
+
+# TODO: Remove -Wno-error=ignored-attributes when the following is fixed:
+# https://bugs.chromium.org/p/boringssl/issues/detail?id=642
 cmake \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes' \
   -DBUILD_SHARED_LIBS=1 ../
 
 ${MAKE} -j ${num_threads}


### PR DESCRIPTION
We won't use some of these differences long term, but at least it gets the build working so we can test with fedora:39.