### PR TITLE
Add pcre2-devel to fedora

### DIFF
--- a/docker/fedora38/Dockerfile
+++ b/docker/fedora38/Dockerfile
@@ -19,7 +19,7 @@ RUN <<EOF
   # Various other tools
   dnf -y install \
     sudo git rpm-build distcc-server file wget openssl hwloc \
-    nghttp2 libnghttp2-devel fmt fmt-devel
+    nghttp2 libnghttp2-devel fmt fmt-devel pcre2-devel
 
   # Devel packages that ATS needs
   dnf -y install \

--- a/docker/fedora39/Dockerfile
+++ b/docker/fedora39/Dockerfile
@@ -20,7 +20,7 @@ RUN <<EOF
   # Various other tools
   dnf -y install \
     sudo git rpm-build distcc-server file wget openssl hwloc \
-    nghttp2 libnghttp2-devel fmt fmt-devel
+    nghttp2 libnghttp2-devel fmt fmt-devel pcre2-devel
 
   # Devel packages that ATS needs
   dnf -y install \


### PR DESCRIPTION
Looks like rockylinux:8 already includes pcre2-devel implicitly somehow.