### PR TITLE
Add lld to ubuntu2304 image

### DIFF
--- a/docker/ubuntu2304/Dockerfile
+++ b/docker/ubuntu2304/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:23.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update; \
-    apt-get -y install build-essential llvm ccache \
+    apt-get -y install build-essential llvm lld ccache \
     make pkgconf bison flex g++ clang gettext libc++-dev autoconf automake \
     libtool autotools-dev git distcc file wget openssl hwloc intltool-debian \
     clang-tools-14 clang-14 ; \


### PR DESCRIPTION
The `ci.trafficserver.apache.org/ats/ubuntu:23.04` image doesn't have `lld` and using old GNU `ld` with llvm toolchain.