### PR TITLE
Revert "Use LLVM toolchain on ubuntu pipeline"

### DIFF
--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -56,7 +56,7 @@ pipeline {
                         autoreconf -fiv
                         mkdir out_of_source_build_dir
                         cd out_of_source_build_dir
-                        CC="clang" CXX="clang++" LD="lld" AR="llvm-ar" NM="llvm-nm" ../configure --enable-experimental-plugins --enable-example-plugins --enable-expensive-tests --prefix=/tmp/ats/ --enable-werror --enable-ccache
+                        CC="clang" CXX="clang++" ../configure --enable-experimental-plugins --enable-example-plugins --enable-expensive-tests --prefix=/tmp/ats/ --enable-werror --enable-ccache
                         make -j4 V=1 Q=
                         make -j4 check VERBOSE=Y V=1
                         make install


### PR DESCRIPTION
This reverts commit 11f23888c3bfa0ec5dad6f0e122297ed60e8e736.

The build using `lld` was failed.

```
+ /tmp/ats/bin/traffic_server -K -k -R 1
/tmp/ats/bin/traffic_server: error while loading shared libraries: ../src/api/.libs/libtsapi.so: cannot open shared object file: No such file or directory
```