### PR TITLE
Convert as many PR builds to cmake as possible

### DIFF
--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -47,21 +47,37 @@ pipeline {
                     sh '''#!/bin/bash
                         set -x
                         set -e
+
                         source /opt/rh/devtoolset-8/enable
-                        autoreconf -fiv
-                        ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-ccache
-                        make -j4 V=1 Q=
-                        make -j 2 check VERBOSE=Y V=1
-                        make install
-                        /tmp/ats/bin/traffic_server -K -k -R 1
+
+                        # We do not support CMake builds for the 9.x branch.
+                        if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            autoreconf -fiv
+                            ./configure --with-openssl=/opt/openssl-quic --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-ccache
+                            make -j4 V=1 Q=
+                            make -j 2 check VERBOSE=Y V=1
+                            make install
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                        else
+                            cmake -B cmake-build-release --preset ci -G "Unix Makefiles" -DOPENSSL_ROOT_DIR=/opt/openssl-quic
+                            cmake --build cmake-build-release -v
+                            cmake --install cmake-build-release
+                            pushd cmake-build-release
+                            ctest -j4 --output-on-failure --no-compress-output -T Test
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            popd
+                        fi
                         '''
                 }
             }
         }
     }
-    
-    post { 
-        cleanup { 
+
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/jenkins/github/cmake.pipeline
+++ b/jenkins/github/cmake.pipeline
@@ -62,7 +62,7 @@ pipeline {
                         export PATH=/opt/bin:${PATH}
 
                         cmake -B cmake-build-release -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DCMAKE_INSTALL_PREFIX=/tmp/ats
-                        cmake --build cmake-build-release -j4 -v
+                        cmake --build cmake-build-release -v
                         cmake --install cmake-build-release
                         pushd cmake-build-release
                         ctest -j4 --output-on-failure --no-compress-output -T Test
@@ -70,7 +70,7 @@ pipeline {
                         popd
 
                         cmake -B cmake-build-quiche -GNinja -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Release -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
-                        cmake --build cmake-build-quiche -j4 -v
+                        cmake --build cmake-build-quiche -v
                         cmake --install cmake-build-quiche
                         pushd cmake-build-quiche
                         ctest -j4 --output-on-failure --no-compress-output -T Test

--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -10,7 +10,7 @@ pipeline {
     environment {
         CCACHE_DIR = "/tmp/ccache"
         CCACHE_BASEDIR = "${WORKSPACE}"
-    }    
+    }
     stages {
         stage('Clone') {
             steps {
@@ -47,20 +47,36 @@ pipeline {
                     sh '''#!/bin/bash
                         set -x
                         set -e
-                        autoreconf -fiv
-                        ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-debug --enable-werror --enable-ccache --enable-hardening
-                        make -j4 V=1 Q=
-                        make -j 2 check VERBOSE=Y V=1
-                        make install
-                        /tmp/ats/bin/traffic_server -K -k -R 1
+                        # We do not support CMake builds for the 9.x branch.
+                        # Always run autotools until -DENABLE_HARDENING=ON is implemented.
+                        if [ true -o \
+                            "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            autoreconf -fiv
+                            ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-debug --enable-werror --enable-ccache --enable-hardening
+                            make -j4 V=1 Q=
+                            make -j 2 check VERBOSE=Y V=1
+                            make install
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                        else
+                            cmake -B cmake-build-release --preset ci -G "Unix Makefiles" -DOPENSSL_ROOT_DIR=/opt/openssl-quic -DENABLE_HARDENING=ON
+                            cmake --build cmake-build-release -v
+                            cmake --install cmake-build-release
+                            pushd cmake-build-release
+                            ctest -j4 --output-on-failure --no-compress-output -T Test
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            popd
+                        fi
                     '''
                 }
             }
         }
     }
-    
-    post { 
-        cleanup { 
+
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -43,6 +43,7 @@ pipeline {
                 dir('src') {
                     sh '''#!/bin/bash
                     set -x
+                    set -e
                     # Skip if nothing in doc has changed
                     INCLUDE_FILES=$(for i in $(git grep literalinclude doc/ | awk '{print $3}'); do basename $i; done | sort -u | paste -sd\\|)
                     echo $INCLUDE_FILES
@@ -55,12 +56,17 @@ pipeline {
                     fi
 
                     sudo chmod -R 777 . || exit 1
-                    cd doc
-                    pipenv install || exit 1
 
-                    tmpfile=/tmp/build_the_docs.$$
+                    # We do not support CMake builds for the 9.x branch.
+                    if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                         "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                         "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                    then
+                        cd doc
+                        pipenv install || exit 1
 
-                    cat << _END_OF_DOC_ > ${tmpfile}
+                        tmpfile=/tmp/build_the_docs.$$
+                        cat << _END_OF_DOC_ > ${tmpfile}
 #!/bin/bash
 set -e
 set -x
@@ -76,11 +82,20 @@ fi
 make -j4 -e SPHINXOPTS="${sphinxopts}" html
 _END_OF_DOC_
 
-                    chmod 755 ${tmpfile}
-                    echo "Running:"
-                    cat ${tmpfile}
-                    pipenv run ${tmpfile} || exit 1
-                    rm ${tmpfile}
+                        chmod 755 ${tmpfile}
+                        echo "Running:"
+                        cat ${tmpfile}
+                        pipenv run ${tmpfile} || exit 1
+                        rm ${tmpfile}
+
+                    else
+                        # cmake. Much easier.
+                        cmake -B docs-build -DENABLE_DOCS=ON
+                        cmake --build docs-build --target generate_docs -v
+
+                        # The rest of the script expects to be just above the html output directory.
+                        cd docs-build/doc
+                    fi
 
                     # If we made it here, the doc build ran and succeeded. Let's copy out the
                     # docbuild contents so it can be published.

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -48,16 +48,31 @@ pipeline {
                         set -x
                         set -e
 
-                        # We don't use c++20 features yet, but we want to make
-                        # sure we can build with the flag set.
-                        export CXXSTD=20
+                        # We do not support CMake builds for the 9.x branch.
+                        if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            # We don't use c++20 features yet, but we want to make
+                            # sure we can build with the flag set.
+                            export CXXSTD=20
 
-                        autoreconf -fiv
-                        ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-ccache
-                        make -j4 V=1 Q=
-                        make -j4 check VERBOSE=Y V=1
-                        make install
-                        /tmp/ats/bin/traffic_server -K -k -R 1
+                            autoreconf -fiv
+                            ./configure --enable-experimental-plugins --enable-example-plugins --prefix=/tmp/ats/ --enable-werror --enable-debug --enable-wccp --enable-ccache
+                            make -j4 V=1 Q=
+                            make -j4 check VERBOSE=Y V=1
+                            make install
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                        else
+                            sed -i 's/CMAKE_CXX_STANDARD 17/CMAKE_CXX_STANDARD 20/g' CMakeLists.txt
+                            cmake -B build --preset ci
+                            cmake --build build -v
+                            cmake --install build
+                            pushd build
+                            ctest -j4 --output-on-failure --no-compress-output -T Test
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            popd
+                        fi
                     '''
                 }
             }

--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -20,16 +20,31 @@ pipeline {
             steps {
                 echo 'Starting build'
                 dir('src') {
-                    sh('autoreconf -fiv')
-                    sh('./configure --enable-experimental-plugins')
-                    sh('gmake -j3')
+                    sh '''#!/bin/bash
+
+                        set -x
+                        set -e
+
+                        # We do not support CMake builds for the 9.x branch.
+                        if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            autoreconf -fiv
+                            ./configure --enable-experimental-plugins
+                            gmake -j3
+                        else
+                            cmake -B cmake-build-release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DCMAKE_INSTALL_PREFIX=/tmp/ats
+                            cmake --build cmake-build-release -v
+                        fi
+                        '''
                 }
             }
         }
     }
-    
-    post { 
-        cleanup { 
+
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/jenkins/github/osx.pipeline
+++ b/jenkins/github/osx.pipeline
@@ -20,16 +20,32 @@ pipeline {
             steps {
                 echo 'Starting build'
                 dir('src') {
-                    sh('autoreconf -fiv')
-                    sh('CC="clang" CXX="clang++" CXXFLAGS="-Qunused-arguments" WITH_LIBCPLUSPLUS="yes" ./configure --enable-experimental-plugins --with-openssl=/usr/local/opt/openssl --enable-werror')
-                    sh('make -j3')
+                    sh '''#!/bin/bash
+                        set -x
+                        set -e
+
+                        # We do not support CMake builds for the 9.x branch.
+                        if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            autoreconf -fiv
+                            CC="clang" CXX="clang++" CXXFLAGS="-Qunused-arguments" WITH_LIBCPLUSPLUS="yes" ./configure --enable-experimental-plugins --with-openssl=/usr/local/opt/openssl --enable-werror
+                            make -j3
+                        else
+                            export CC="clang"
+                            export CXX="clang++"
+                            cmake -B build --preset ci -G "Unix Makefiles" -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl
+                            cmake --build build -j3 -v
+                        fi
+                    '''
                 }
             }
         }
     }
-    
-    post { 
-        cleanup { 
+
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/jenkins/github/rat.pipeline
+++ b/jenkins/github/rat.pipeline
@@ -58,9 +58,9 @@ pipeline {
             }
         }
     }
-    
-    post { 
-        cleanup { 
+
+    post {
+        cleanup {
             cleanWs()
         }
     }

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -71,10 +71,10 @@ pipeline {
                             make install
                             /tmp/ats/bin/traffic_server -K -k -R 1
                         else
-                            cmake -B cmake-build-quiche -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_QUICHE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_EXPERIMENTAL_PLUGINS=ON -Dquiche_ROOT=/opt/quiche -DOPENSSL_ROOT_DIR=/opt/boringssl -DCMAKE_INSTALL_PREFIX=/tmp/ats_quiche
-                            cmake --build cmake-build-quiche -j4 -v
-                            cmake --install cmake-build-quiche
-                            pushd cmake-build-quiche
+                            cmake -B build --preset ci-rocky
+                            cmake --build build -v
+                            cmake --install build
+                            pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
                             /tmp/ats_quiche/bin/traffic_server -K -k -R 1
                             popd

--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -49,18 +49,39 @@ pipeline {
                         set -x
                         set -e
 
-                        # We don't use c++20 features yet, but we want to make
-                        # sure we can build with the flag set.
-                        export CXXSTD=20
+                        # We do not support CMake builds for the 9.x branch.
+                        if [ "${GITHUB_PR_TARGET_BRANCH}" == "9.0.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.1.x" -o \
+                             "${GITHUB_PR_TARGET_BRANCH}" == "9.2.x" ]
+                        then
+                            # We don't use c++20 features yet, but we want to make
+                            # sure we can build with the flag set.
+                            export CXXSTD=20
 
-                        autoreconf -fiv
-                        mkdir out_of_source_build_dir
-                        cd out_of_source_build_dir
-                        CC="clang" CXX="clang++" ../configure --enable-experimental-plugins --enable-example-plugins --enable-expensive-tests --prefix=/tmp/ats/ --enable-werror --enable-ccache
-                        make -j4 V=1 Q=
-                        make -j4 check VERBOSE=Y V=1
-                        make install
-                        /tmp/ats/bin/traffic_server -K -k -R 1
+                            autoreconf -fiv
+                            mkdir out_of_source_build_dir
+                            cd out_of_source_build_dir
+                            CC="clang" CXX="clang++" ../configure --enable-experimental-plugins --enable-example-plugins --enable-expensive-tests --prefix=/tmp/ats/ --enable-werror --enable-ccache
+                            make -j4 V=1 Q=
+                            make -j4 check VERBOSE=Y V=1
+                            make install
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                        else
+                            export CC="clang"
+                            export CXX="clang++"
+
+                            # We don't use c++20 features yet, but we want to make
+                            # sure we can build with the flag set.
+                            sed -i 's/CMAKE_CXX_STANDARD 17/CMAKE_CXX_STANDARD 20/g' CMakeLists.txt
+
+                            cmake -B build --preset ci -G "Unix Makefiles"
+                            cmake --build build -v
+                            cmake --install build
+                            pushd build
+                            ctest -j4 --output-on-failure --no-compress-output -T Test
+                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            popd
+                        fi
                     '''
                 }
             }


### PR DESCRIPTION
We'll still need a rat target and an -DENABLE_HARDENING=ON feature. But most of the PR builds can be done via cmake now.