### PR TITLE
freebsd: avoid cmake until it's installed in CI

### DIFF
--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -25,7 +25,8 @@ pipeline {
                         set -x
                         set -e
 
-                        if [ -d cmake ]
+                        # Avoid doing cmake builds for freebsd until we install cmake on the CI boxes.
+                        if [ false -a -d cmake ]
                         then
                             cmake -B cmake-build-release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DCMAKE_INSTALL_PREFIX=/tmp/ats
                             cmake --build cmake-build-release -v


### PR DESCRIPTION
We'll install cmake on freebsd shortly, but for now avoid cmake builds until that is done.