### PR TITLE
Revert "cmake: update freebsd builds to use cmake (#234)"

### DIFF
--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -25,7 +25,8 @@ pipeline {
                         set -x
                         set -e
 
-                        if [ -d cmake ]
+                        # `1 -eq 0`: Avoid doing cmake builds for freebsd until we install cmake on the CI boxes.
+                        if [ 1 -eq 0 -a -d cmake ]
                         then
                             cmake -B cmake-build-release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DCMAKE_INSTALL_PREFIX=/tmp/ats
                             cmake --build cmake-build-release -v


### PR DESCRIPTION
This reverts commit 8f66b112dca6aa164db3488c7f642a0e81667072.

Reverting until the following is resolved for ATS builds for freebsd: 
https://github.com/apache/trafficserver/issues/10620