### PR TITLE
Revert "cmake: try freebsd again"

### DIFF
--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -25,7 +25,8 @@ pipeline {
                         set -x
                         set -e
 
-                        if [ -d cmake ]
+                        # `1 -eq 0`: Avoid doing cmake builds for freebsd until we install cmake on the CI boxes.
+                        if [ 1 -eq 0 -a -d cmake ]
                         then
                             cmake -B cmake-build-release -DBUILD_EXPERIMENTAL_PLUGINS=ON -DCMAKE_INSTALL_PREFIX=/tmp/ats
                             cmake --build cmake-build-release -v


### PR DESCRIPTION
Reverts apache/trafficserver-ci#237

Reverting until we get freebsd working pthread_create:

```
[ 25%] Linking CXX executable test_tscore
cd /usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release/src/tscore && /usr/local/bin/cmake -E cmake_link_script CMakeFiles/test_tscore.dir/link.txt --verbose=1
/usr/bin/c++ CMakeFiles/test_tscore.dir/unit_tests/test_AcidPtr.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_ArgParser.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_CryptoHash.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Errata.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Extendible.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Encoding.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_HKDF.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Histogram.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_History.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_IntrusivePtr.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_List.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_MMH.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_ParseRules.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_PluginUserArgs.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_PriorityQueue.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Ptr.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Random.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Regex.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Throttler.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Tokenizer.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_Version.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_arena.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_ink_inet.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_ink_memory.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_ink_string.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_layout.cc.o CMakeFiles/test_tscore.dir/unit_tests/test_scoped_resource.cc.o CMakeFiles/test_tscore.dir/unit_tests/unit_test_main.cc.o -o test_tscore  -Wl,-rpath,/usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release/src/tscpp/util:/usr/local/lib:/usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release/lib/swoc:/usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release/lib/yamlcpp libtscore.a ../api/libtsapicore.a ../tscpp/util/libtscpputil.so /usr/local/lib/libcrypto.so /usr/local/lib/libssl.so libtscore.a ../../lib/swoc/libswoc-1.5.5.so /usr/local/lib/libhwloc.so /usr/local/lib/libpcre.so ../../lib/yamlcpp/libyaml-cpp.so.0.8.0 /usr/local/lib/libcrypto.so 
ld: error: undefined symbol: pthread_create
>>> referenced by test_AcidPtr.cc
>>>               CMakeFiles/test_tscore.dir/unit_tests/test_AcidPtr.cc.o:(std::__1::__libcpp_thread_create(pthread**, void* (*)(void*), void*))
c++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [src/tscore/CMakeFiles/test_tscore.dir/build.make:540: src/tscore/test_tscore] Error 1
gmake[2]: Leaving directory '/usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release'
gmake[1]: *** [CMakeFiles/Makefile2:3710: src/tscore/CMakeFiles/test_tscore.dir/all] Error 2
gmake[1]: Leaving directory '/usr/home/jenkins/workspace/Github_Builds/freebsd/src/cmake-build-release'
gmake: *** [Makefile:146: all] Error 2
```