### PR TITLE
add check for override cmake presets, clean up nproc

### DIFF
--- a/jenkins/bin/clang-analyzer.sh
+++ b/jenkins/bin/clang-analyzer.sh
@@ -34,6 +34,7 @@ mkdir -p ${RPTDIR}
 
 if [ -d cmake ]
 then
+  echo "Building with CMake"
 
   # copy in CMakePresets.json
   presetpath="${WORKSPACE}/ci/jenkins/branch/CMakePresets.json"
@@ -55,6 +56,8 @@ then
     --html-title="clang-analyzer: ${GITHUB_BRANCH}"
 
 else
+  echo "Building with autotools"
+
   autoreconf -fiv
   ${SCAN_BUILD} --keep-cc \
     ./configure --enable-experimental-plugins --with-luajit

--- a/jenkins/bin/cmake_basic.sh
+++ b/jenkins/bin/cmake_basic.sh
@@ -20,7 +20,7 @@
 
 set -x
 
-NPROC=`nproc`
+NPROC=$(nproc)
 
 if [ ! -d cmake ]
 then
@@ -30,17 +30,15 @@ fi
 
 cd "${WORKSPACE}/src"
 
-cmake -B cmake-build-release\
-  -GNinja \
-  -DCMAKE_COMPILE_WARNING_AS_ERROR=ON \
-  -DCMAKE_BUILD_TYPE=Release \
-  -DBUILD_EXPERIMENTAL_PLUGINS=ON \
-  -DCMAKE_INSTALL_PREFIX=/tmp/ats
-#  -DOPENSSL_ROOT_DIR=/opt/openssl-quic
-cmake --build cmake-build-release -j${NPROC} -v
-cmake --install cmake-build-release
+# copy in CMakePresets.json
+presetpath="${WORKSPACE}/ci/jenkins/branch/CMakePresets.json"
+[ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
 
-pushd cmake-build-release
+cmake -B build --preset=branch-release
+cmake --build build -j${NPROC} -v
+cmake --install build
+
+pushd build
 ctest -j${NPROC} --output-on-failure --no-compress-output -T Test
 /tmp/ats/bin/traffic_server -K -k -R 1
 popd

--- a/jenkins/bin/format.sh
+++ b/jenkins/bin/format.sh
@@ -43,13 +43,21 @@ echo "Success! No DOS carriage return"
 
 set -x
 
+NPROC=$(nproc)
+
 if [ -d cmake ]
 then
+  echo "Building with CMake"
 
-  cmake -B build
-	cmake --build build --target format -j`nproc` -v || exit 1
+  presetpath="${WORKSPACE}/ci/jenkins/branch/CMakePresets.json"
+  [ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
+
+  cmake -B build --preset=branch
+  cmake --build build --target format -j${NPROC} -v || exit 1
 
 else
+  echo "Building with autotools"
+
   autoreconf -if
   ./configure
 

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -87,6 +87,8 @@ pipeline {
 						# depend upon this, so update the PATH accordingly.
 						export PATH=/opt/bin:${PATH}
 
+						NPROC=$(nproc)
+
 						if [ -d cmake ]
 						then
 							echo "Building with CMake"
@@ -95,7 +97,7 @@ pipeline {
 							[ -f "${presetpath}" ] && cp -f "${presetpath}" .
 
 							cmake -B build --preset branch-autest
-							cmake --build build -j`nproc` -v
+							cmake --build build -j${NPROC} -v
 							cmake --install build -v
 
 						else
@@ -113,7 +115,7 @@ pipeline {
 								--enable-wccp \
 								--enable-luajit \
 								--enable-ccache
-							make -j`nproc`
+							make -j${NPROC}
 							make install
 
 						fi

--- a/jenkins/branch/cache-tests.pipeline
+++ b/jenkins/branch/cache-tests.pipeline
@@ -55,16 +55,17 @@ pipeline {
 							export PATH=/opt/bin:${PATH}
 							chmod -R o+r .
 
+							NPROC=$(nproc)
+
 							if [ -d cmake ]
 							then
-								cmake -B build \
-									-DCMAKE_INSTALL_PREFIX=/opt/ats
-								cmake --build build -j`nproc` -v
+								cmake -B build -DCMAKE_INSTALL_PREFIX=/opt/ats
+								cmake --build build -j${NPROC} -v
 								cmake --install build
 							else
 								autoreconf -fiv
 								./configure --prefix=/opt/ats --enable-ccache
-								make -j`nproc`
+								make -j${NPROC}
 								make install
 							fi
 

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -80,15 +80,17 @@ pipeline {
 						# (default user umask may change and make these unreadable)
 						sudo chmod -R o+r .
 
+						NPROC=$(nproc)
+
 						if [ -d cmake ]
 						then
 							echo "Building with CMake"	
 
 							presetpath="../ci/jenkins/branch/CMakePresets.json"
-              [ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
+							[ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
 
-							cmake -B build --preset branch-coverage -DCMAKE_INSTALL_PREFIX="/tmp/ats"
-							cmake --build build -j`nproc` -v
+							cmake -B build --preset branch-coverage
+							cmake --build build -j${NPROC} -v
 							cmake --install build -v
 
 						else
@@ -105,7 +107,7 @@ pipeline {
 								--enable-luajit \
 								--enable-ccache \
 								--enable-coverage
-							make -j`nproc` V=1 Q=
+							make -j${NPROC} V=1 Q=
 							make install
 						fi
 					'''

--- a/jenkins/branch/coverity.pipeline
+++ b/jenkins/branch/coverity.pipeline
@@ -38,20 +38,27 @@ pipeline {
 						tar -xvzf coverity_tool.tgz -C cov_tools --strip-components 1
 						set -x
 
+						NPROC=$(nproc)
+
 						if [ -d cmake ]
 						then
+							echo "Building with CMake"
+
 							presetpath="../ci/jenkins/branch/CMakePresets.json"
 							[ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
+
 							cmake -B build --preset branch-coverity
 							pushd build
-						  ../cov_tools/bin/cov-build --dir ../cov-int make -j`nproc`
+						  ../cov_tools/bin/cov-build --dir ../cov-int make -j${NPROC}
 							popd
 						else
+							echo "Building with autotools"
+
 							autoreconf -fiv
 							./configure \
 								--enable-experimental-plugins \
 								--enable-example-plugins
-						  ./cov_tools/bin/cov-build --dir cov-int make -j`nproc`
+						  ./cov_tools/bin/cov-build --dir cov-int make -j${NPROC}
 						fi
 
 						tar czvf trafficserver.tgz cov-int

--- a/jenkins/branch/freebsd.pipeline
+++ b/jenkins/branch/freebsd.pipeline
@@ -28,14 +28,23 @@ pipeline {
 						set -x
 						set -e
 
+						NPROC=$(nproc)
+
 						if [ -d cmake ]
 						then
+							echo "Building with CMake"
+
+							presetpath="../ci/jenkins/branch/CMakePresets.json"
+							[ -f "${presetpath}" ] && cp -f "${presetpath}" .
+
 							cmake -B build --preset=branch-freebsd
-							cmake --build build -j`nproc` -v
+							cmake --build build -j${NPROC} -v
 						else
+							echo "Building with autotools"
+
 							autoreconf -fiv
 							./configure --enable-experimental-plugins
-							gmake -j3
+							gmake -j${NPROC}
 						fi
 					'''
 				}

--- a/jenkins/branch/osx-m1.pipeline
+++ b/jenkins/branch/osx-m1.pipeline
@@ -28,23 +28,31 @@ pipeline {
 						set -x
 						set -e
 
+						NPROC=3
+
 						if [ -d cmake ]
 						then
+							echo "Building with CMake"
+
+							presetpath="../ci/jenkins/branch/CMakePresets.json"
+							[ -f "${presetpath}" ] && cp -f "${presetpath}" .
+
 							CC="clang" \
 								CXX="clang++" \
 								CXXFLAGS="-Qunused-arguments" \
 								WITH_LIBCPLUSPLUS="yes" \
 								cmake -B build --preset=branch-osx-m1
-							cmake --build build -j3 -v
+							cmake --build build -j${NPROC} -v
 						else
+							echo "Building with autotools"
+
 							autoreconf -fiv
 							CC="clang" \
 							CXX="clang++" \
 							CXXFLAGS="-Qunused-arguments" \
 							WITH_LIBCPLUSPLUS="yes" \
-							./configure \
-								--with-openssl=/opt/homebrew/opt/openssl
-							make -j3
+							./configure --with-openssl=/opt/homebrew/opt/openssl
+							make -j${NPROC}
 						fi
 					'''
 				}

--- a/jenkins/branch/osx.pipeline
+++ b/jenkins/branch/osx.pipeline
@@ -28,15 +28,24 @@ pipeline {
 						set -x
 						set -e
 
+						NPROC=3
+
 						if [ -d cmake ]
 						then
+							echo "Building with CMake"
+
+							presetpath="../ci/jenkins/branch/CMakePresets.json"
+							[ -f "${presetpath}" ] && cp -f "${presetpath}" .
+
 							CC="clang" \
 								CXX="clang++" \
 								CXXFLAGS="-Qunused-arguments" \
 								WITH_LIBCPLUSPLUS="yes" \
 								cmake -B build --preset branch-osx
-								cmake --build build -j3 -v
+							cmake --build build -j${NPROC} -v
 						else
+							echo "Building with autotools"
+
 							autoreconf -fiv
 							CC="clang" \
 								CXX="clang++" \
@@ -45,7 +54,7 @@ pipeline {
 								./configure \
 								--enable-experimental-plugins \
 								--with-openssl=/usr/local/opt/openssl
-							make -j3
+							make -j${NPROC}
 						fi
 					'''
 				}


### PR DESCRIPTION
This adds more checks for existence of override branch CMakePresets and also unifies the use of NPROC in scripts and pipelines.