### PR TITLE
simplify setting json contents for CMakeUserPresets.json

### DIFF
--- a/jenkins/bin/cmake.sh
+++ b/jenkins/bin/cmake.sh
@@ -57,17 +57,17 @@ done
 # comma separate
 inherits=$(sed 's/ /, /g' <<< "${farray[@]}")
 
-read -d '' contents << EOF
+contents="
 {
-  "version": 2,
-  "configurePresets": [
+  \"version\": 2,
+  \"configurePresets\": [
     { 
-      "name": "branch-user-preset", 
-      "inherits": [${inherits}]
+      \"name\": \"branch-user-preset\", 
+      \"inherits\": [${inherits}]
     } 
   ] 
 }
-EOF
+"
 
 echo "${contents}" > CMakeUserPresets.json
 


### PR DESCRIPTION
The read statement for using a block was returning '1' for some reason and blowing up with set -e
This replaces it with just setting the contents with an escaped multiline string.