### PR TITLE
build_h3_tools updates for static boringssl

### DIFF
--- a/docker/rockylinux8/build_h3_tools.sh
+++ b/docker/rockylinux8/build_h3_tools.sh
@@ -136,14 +136,23 @@ if [ ! -d boringssl ]; then
 fi
 cd boringssl
 cmake \
-  -B build \
+  -B build-shared \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes' \
   -DBUILD_SHARED_LIBS=1
-cmake --build build -j ${num_threads}
-cmake --install build
+cmake \
+  -B build-static \
+  -DGO_EXECUTABLE=${GO_BINARY_PATH} \
+  -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes' \
+  -DBUILD_SHARED_LIBS=0
+cmake --build build-shared -j ${num_threads}
+cmake --build build-static -j ${num_threads}
+cmake --install build-shared
+cmake --install build-static
 chmod -R a+rX ${BASE}
 cd ..
 

--- a/docker/rockylinux9/build_h3_tools.sh
+++ b/docker/rockylinux9/build_h3_tools.sh
@@ -136,14 +136,23 @@ if [ ! -d boringssl ]; then
 fi
 cd boringssl
 cmake \
-  -B build \
+  -B build-shared \
   -DGO_EXECUTABLE=${GO_BINARY_PATH} \
   -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes' \
   -DBUILD_SHARED_LIBS=1
-cmake --build build -j ${num_threads}
-cmake --install build
+cmake \
+  -B build-static \
+  -DGO_EXECUTABLE=${GO_BINARY_PATH} \
+  -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS='-Wno-error=ignored-attributes' \
+  -DBUILD_SHARED_LIBS=0
+cmake --build build-shared -j ${num_threads}
+cmake --build build-static -j ${num_threads}
+cmake --install build-shared
+cmake --install build-static
 chmod -R a+rX ${BASE}
 cd ..
 


### PR DESCRIPTION
This failed for fedora:39, so not updating that.