### PR TITLE
fedora build to use 40

### DIFF
--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         docker {
-            image 'ats/fedora:39'
+            image 'ats/fedora:40'
             //registryUrl 'https://ci.trafficserver.apache.org/'
             args '-v ${HOME}/ccache:/tmp/ccache:rw'
             label 'linux'


### PR DESCRIPTION
The autest build has at least v6 resolution issues which I hope will get resolved as fedora hardens up and comes out of beta. But for now we can at least use the updated compiler from fedora:40