### PR TITLE
regression.sh: ctest exit with 1 on failure

### DIFF
--- a/jenkins/bin/regression.sh
+++ b/jenkins/bin/regression.sh
@@ -34,7 +34,7 @@ echo -n "Unit tests started at " && date
 if [ -d cmake ]
 then
 	pushd build
-	ctest -j${NPROC} --output-on-failure --no-compress-output -T Test
+	ctest -j${NPROC} --output-on-failure --no-compress-output -T Test || exit 1
 	popd
 else
   ${ATS_MAKE} -j${NPROC} check VERBOSE=Y V=1 || exit 1


### PR DESCRIPTION
Without the explicit `exit 1` the script finishes with an exit code of 8 which was maybe making it so the tests didn't fail. Maybe? In any case, this shouldn't hurt and may make the failure explicit in jenkins.