### PR TITLE
fedora:40 - update curl to version 8.7.1

### DIFF
--- a/docker/fedora40/build_h3_tools.sh
+++ b/docker/fedora40/build_h3_tools.sh
@@ -254,7 +254,7 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_5_0 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b curl-8_7_1 https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.


### PR DESCRIPTION
This helps at least the bigobj.test.py ATS autest run better.