### PR TITLE
github autest pipeline: use fedora:40

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -1,7 +1,7 @@
 pipeline {
 	agent {
 		docker {
-			image 'ci.trafficserver.apache.org/ats/fedora:39'
+			image 'ci.trafficserver.apache.org/ats/fedora:40'
 			registryUrl 'https://ci.trafficserver.apache.org/'
 			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'docker'


### PR DESCRIPTION
This updates the autest github PR pipeline to use fedora:40