### PR TITLE
quiche branch builds: support openssl

### DIFF
--- a/jenkins/bin/quiche.sh
+++ b/jenkins/bin/quiche.sh
@@ -28,13 +28,19 @@ then
   exit 0
 fi
 
+SSL_FLAVOR="boringssl"
+if [ $# -eq 2 ]
+then
+  SSL_FLAVOR=$1
+fi
+
 cd "${WORKSPACE}/src"
 
 # copy in CMakePresets.json
 presetpath="../ci/jenkins/branch/CMakePresets.json"
 [ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
 
-cmake -B build --preset branch-quiche-on-boringssl
+cmake -B build --preset branch-quiche-on-${SSL_FLAVOR}
 cmake --build build -j${NPROC} -v
 cmake --install build
 

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -68,7 +68,7 @@ pipeline {
 					set -e
 					export PATH=/opt/bin:${PATH}
 					source ../ci/jenkins/bin/environment.sh
-					../ci/jenkins/bin/quiche.sh
+					../ci/jenkins/bin/quiche.sh ${SSL_FLAVOR}
 					'''
 				}
 			}


### PR DESCRIPTION
Support quiche built on top of openssl as well as boringssl.