### PR TITLE
Add --privileged to github autest docker container

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -3,7 +3,7 @@ pipeline {
 		docker {
 			image 'ci.trafficserver.apache.org/ats/fedora:40'
 			registryUrl 'https://ci.trafficserver.apache.org/'
-			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
+			args '--init --privileged --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'docker'
 		}
 	}

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -3,7 +3,7 @@ pipeline {
 		docker {
 			image 'ci.trafficserver.apache.org/ats/fedora:40'
 			registryUrl 'https://ci.trafficserver.apache.org/'
-			args '--init --privileged --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
+			args '--init --privileged --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'docker'
 		}
 	}


### PR DESCRIPTION
We wish to add an autest for eBPF tracing.  Using eBPF tracing inside a docker container requires the container to be `--privileged`.  After kernel 5.8 there is CAP_BPF, but the VM that we run on has kernel 5.4.