### PR TITLE
Revert "Add --privileged to github autest docker container"

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -3,7 +3,7 @@ pipeline {
 		docker {
 			image 'ci.trafficserver.apache.org/ats/fedora:40'
 			registryUrl 'https://ci.trafficserver.apache.org/'
-			args '--init --privileged --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
+			args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
 			label 'docker'
 		}
 	}


### PR DESCRIPTION
Running bpftrace in the docker is going to require root-level access in the container, which is problematic when the container is privileged.  Let's not run that autest in CI.