### PR TITLE
fedora:40 rockylinux:8 build_h3_tools_updates

### DIFF
--- a/docker/fedora40/build_openssl_h3_tools.sh
+++ b/docker/fedora40/build_openssl_h3_tools.sh
@@ -127,7 +127,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.21.0
+git checkout 0.22.0
 
 PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
   cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
@@ -136,6 +136,8 @@ mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 mkdir -p ${QUICHE_BASE}/include
 cp target/release/libquiche.a ${QUICHE_BASE}/lib/
 [ -f target/release/libquiche.so ] && cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+ln -s ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
 cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 chmod -R a+rX ${BASE}

--- a/docker/rockylinux8/build_openssl_h3_tools.sh
+++ b/docker/rockylinux8/build_openssl_h3_tools.sh
@@ -127,7 +127,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.21.0
+git checkout 0.22.0
 
 PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
   cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
@@ -136,6 +136,8 @@ mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 mkdir -p ${QUICHE_BASE}/include
 cp target/release/libquiche.a ${QUICHE_BASE}/lib/
 [ -f target/release/libquiche.so ] && cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+# Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+ln -s ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
 cp quiche/include/quiche.h ${QUICHE_BASE}/include/
 cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
 chmod -R a+rX ${BASE}


### PR DESCRIPTION
build_h3_tools updates from master and:
https://github.com/apache/trafficserver/pull/11493