### PR TITLE
fedora:41 Add openssl-devel-engine

### DIFF
--- a/docker/fedora41/Dockerfile
+++ b/docker/fedora41/Dockerfile
@@ -26,7 +26,7 @@ RUN <<EOF
 
   # Devel packages that ATS needs
   dnf -y install \
-    openssl-devel expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
+    openssl-devel openssl-devel-engine expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
     xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
     ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
     perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI perl-IPC-Cmd perl-Pod-Html \


### PR DESCRIPTION
openssl-devel-engine is needed since the Engine API is removed in fedora:41 due to it being deprecated in OpenSSL 3.*. The following ATS issue tracks this problem:
https://github.com/apache/trafficserver/issues/7512