### PR TITLE
Revert "I think this hard-coding isn't needed anymore"

### DIFF
--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -72,6 +72,11 @@ pipeline {
 
                     sudo chmod -R 777 . || exit 1
 
+                    # Sphinx 8.1 requires a recent version of Python.
+                    export PIPENV_VENV_IN_PROJECT=1
+                    python3.12 -m pipenv install --python python3.12
+                    source .venv/bin/activate
+
                     if [ -d cmake ]
                     then
                         cmake -B docs-build --preset ci-docs


### PR DESCRIPTION
Reverts apache/trafficserver-ci#372

Nevermind: it looks like this is needed lest Python3.6 (the rockylinux:8 system default) is used.