### PR TITLE
remove -k to traffic_server for cmake builds

### DIFF
--- a/jenkins/bin/cmake.sh
+++ b/jenkins/bin/cmake.sh
@@ -80,4 +80,4 @@ cmake --install build
 #popd
 
 #chmod -R go+w /tmp/ats
-#/tmp/ats/bin/traffic_server -K -k -R 1
+#/tmp/ats/bin/traffic_server -K -R 1

--- a/jenkins/bin/cmake_basic.sh
+++ b/jenkins/bin/cmake_basic.sh
@@ -40,5 +40,5 @@ cmake --install build
 
 pushd build
 ctest -j${NPROC} --output-on-failure --no-compress-output -T Test
-/tmp/ats/bin/traffic_server -K -k -R 1
+/tmp/ats/bin/traffic_server -K -R 1
 popd

--- a/jenkins/bin/quiche.sh
+++ b/jenkins/bin/quiche.sh
@@ -46,5 +46,5 @@ cmake --install build
 
 #pushd cmake-build-quiche
 #ctest -j${NPROC} --output-on-failure --no-compress-output -T Test
-#/tmp/ats_quiche/bin/traffic_server -K -k -R 1
+#/tmp/ats_quiche/bin/traffic_server -K -R 1
 #popd

--- a/jenkins/bin/regression.sh
+++ b/jenkins/bin/regression.sh
@@ -44,7 +44,7 @@ echo -n "Unit tests finished at " && date
 
 echo
 echo -n "Regression tests started at " && date
-/tmp/ats/bin/traffic_server -k -K -R 1
+/tmp/ats/bin/traffic_server -K -R 1
 rval=$?
 echo -n "Regression tests finished at " && date
 exit $rval

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -167,7 +167,7 @@ pipeline {
 						[ "${RUN_REGRESSION_TESTS}" == "true" ] || exit 0
 						chmod -R go+w .
 						chmod -R go+w /tmp/ats/
-						/tmp/ats/bin/traffic_server -K -k -R 1
+						/tmp/ats/bin/traffic_server -K -R 1
 					 '''
 				}
 				echo 'Starting AuTest'

--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -76,7 +76,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            /tmp/ats/bin/traffic_server -K -R 1
                             popd
                         else
                             # Pre 10 branches only supported autotools.

--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -70,7 +70,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            /tmp/ats/bin/traffic_server -K -R 1
                             popd
                         else
                             # Pre 10.x branches only supported autotools.

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -73,7 +73,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            /tmp/ats/bin/traffic_server -K -R 1
                             popd
                         else
                             # Pre 10.x branches only support autotools.

--- a/jenkins/github/osx.pipeline
+++ b/jenkins/github/osx.pipeline
@@ -64,7 +64,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j3 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            /tmp/ats/bin/traffic_server -K -R 1
                             popd
                         else
                             # Pre 10.x branches only support autotools.

--- a/jenkins/github/rocky-asan.pipeline
+++ b/jenkins/github/rocky-asan.pipeline
@@ -78,7 +78,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats-quiche/bin/traffic_server -K -k -R 1
+                            /tmp/ats-quiche/bin/traffic_server -K -R 1
                             popd
                         else
                             echo "CMake builds are not supported for the this branch."

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -80,7 +80,7 @@ pipeline {
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
                             LSAN_OPTIONS=suppressions=${src_top}/ci/asan_leak_suppression/regression.txt \
-                            /tmp/ats-quiche/bin/traffic_server -K -k -R 1
+                            /tmp/ats-quiche/bin/traffic_server -K -R 1
                             popd
                         else
                             echo "CMake builds are not supported for the this branch."

--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -75,7 +75,7 @@ pipeline {
                             cmake --install build
                             pushd build
                             ctest -j4 --output-on-failure --no-compress-output -T Test
-                            /tmp/ats/bin/traffic_server -K -k -R 1
+                            /tmp/ats/bin/traffic_server -K -R 1
                             popd
                         else
                             # Pre 10.x branches only support autotools.


### PR DESCRIPTION
Trying to remove the `-k` parameter caused problems with the CI builds