### PR TITLE
Add Fedora 44 CI image

### DIFF
--- a/docker/fedora44/Dockerfile
+++ b/docker/fedora44/Dockerfile
@@ -1,0 +1,274 @@
+FROM fedora:44 AS build
+
+#-------------------------------------------------------------------------------
+# Install the various system packages we use.
+#
+# Try to keep all or at least most dnf commands at the beginning and clean
+# afterwards to keep the Docker images smaller.
+#-------------------------------------------------------------------------------
+RUN <<EOF
+  set -e
+
+  dnf -y install dnf-plugins-core
+  dnf repolist
+  dnf -y update
+
+  # Build tools.
+  dnf -y install \
+    ccache make pkgconfig bison flex gcc-c++ clang \
+    autoconf automake libtool \
+    cmake ninja-build
+
+  # Various other tools
+  dnf -y install \
+    sudo git rpm-build distcc-server file wget openssl hwloc \
+    nghttp2 libnghttp2-devel fmt fmt-devel pcre2-devel
+
+  # Devel packages that ATS needs
+  dnf -y install \
+    openssl-devel openssl-devel-engine expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
+    xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
+    ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
+    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI perl-IPC-Cmd perl-Pod-Html perl-Time-Piece \
+    curl tcl-devel java cjose-devel protobuf-devel
+
+  # Needed to install openssl-quic
+  dnf -y install libev-devel jemalloc-devel libxml2-devel \
+    c-ares-devel libevent-devel cjose-devel jansson-devel zlib-devel \
+    systemd-devel perl-FindBin cargo
+
+  # build_h3_tools will install its own version of golang.
+  dnf remove -y golang
+
+  # abi tool dependencies.
+  dnf install -y ctags elfutils-libelf-devel wdiff rfcdiff
+
+  # Cleaning before this RUN command finishes keeps the image size smaller.
+  dnf clean all
+EOF
+
+#-------------------------------------------------------------------------------
+# Install some custom build tools.
+#-------------------------------------------------------------------------------
+
+WORKDIR /root
+
+# We put our custom packages in /opt.
+RUN <<EOF
+  set -e
+  mkdir -p /opt/bin
+  chmod 755 /opt/bin
+  echo 'PATH=/opt/bin:$PATH' | tee -a /etc/profile.d/opt_bin.sh
+EOF
+ARG PATH=/opt/bin:$PATH
+
+#-------------------------------------------------------------------------------
+# Install the HTTP/3 build tools, including openssl-quic.
+#-------------------------------------------------------------------------------
+
+# go will be installed by build_h3_tools.
+ARG h3_tools_dir=/root/build_h3_tools
+RUN mkdir -p ${h3_tools_dir}
+COPY build_boringssl_h3_tools.sh ${h3_tools_dir}
+# boringssl
+RUN <<EOF
+  set -e
+  cd ${h3_tools_dir}
+  export BASE=/opt/h3-tools-boringssl
+  bash ${h3_tools_dir}/build_boringssl_h3_tools.sh
+  cd /root
+  rm -rf ${h3_tools_dir} /root/.rustup
+EOF
+# openssl: These are stored in /opt so that CI can easily access the curl,
+# h2load, etc., from there.
+RUN mkdir -p ${h3_tools_dir}
+COPY build_openssl_h3_tools.sh ${h3_tools_dir}
+RUN <<EOF
+  set -e
+  cd ${h3_tools_dir}
+  export BASE=/opt
+  bash ${h3_tools_dir}/build_openssl_h3_tools.sh
+  cd /root
+  rm -rf ${h3_tools_dir} /root/.rustup
+EOF
+
+#-------------------------------------------------------------------------------
+# Various CI Job and Test Requirements.
+#-------------------------------------------------------------------------------
+
+# Autests require some go applications.
+RUN <<EOF
+  set -e
+  ln -s /opt/h3-tools-boringssl/go /opt/go
+  echo 'export PATH=$PATH:/opt/go/bin' | tee -a /etc/profile.d/go.sh
+  echo 'export GOBIN=/opt/go/bin' | tee -a /etc/profile.d/go.sh
+
+  /opt/go/bin/go install github.com/summerwind/h2spec/cmd/h2spec@latest
+  cp /root/go/bin/h2spec /opt/go/bin/
+
+  /opt/go/bin/go install github.com/mccutchen/go-httpbin/v2/cmd/go-httpbin@v2.6.0
+  cp /root/go/bin/go-httpbin /opt/go/bin/
+EOF
+
+# Install nuraft for the stek_share plugin. Distros, unfortunately, do not
+# package these, so this has to be built by hand.
+RUN <<EOF
+  set -e
+
+  git clone https://github.com/eBay/NuRaft.git
+  cd NuRaft
+  ./prepare.sh
+
+  OPENSSL_PREFIX=/opt/openssl-quic
+  if [ -d "${OPENSSL_PREFIX}/lib" ]; then
+    OPENSSL_LIB="${OPENSSL_PREFIX}/lib"
+  elif [ -d "${OPENSSL_PREFIX}/lib64" ]; then
+    OPENSSL_LIB="${OPENSSL_PREFIX}/lib64"
+  else
+    echo "Could not find the OpenSSL install library directory."
+    exit 1
+  fi
+  cmake \
+    -B build \
+    -G Ninja \
+    -DCMAKE_INSTALL_PREFIX=/opt/ \
+    -DOPENSSL_LIBRARY_PATH=${OPENSSL_LIB} \
+    -DOPENSSL_INCLUDE_PATH=${OPENSSL_PREFIX}/include
+  cmake --build build
+  cmake --install build
+  cd ../
+  rm -rf NuRaft
+EOF
+
+# For Open Telemetry Tracer plugin.
+RUN <<EOF
+  set -e
+
+  cd /root
+  mkdir nlohmann-json
+  cd nlohmann-json
+  wget https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
+  tar zxf v3.11.3.tar.gz
+  cd json-3.11.3
+  cmake -B build -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_INSTALL_PREFIX=/opt -DJSON_BuildTests=OFF
+  cmake --build build
+  cmake --install build
+  cd /root
+  rm -rf nlohmann-json
+
+  mkdir opentelemetry-cpp
+  cd opentelemetry-cpp
+  wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.3.0.tar.gz
+  tar zxf v1.3.0.tar.gz
+  cd opentelemetry-cpp-1.3.0
+  cmake -B build -G Ninja -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -Dnlohmann_json_ROOT=/opt/ -DCMAKE_INSTALL_PREFIX=/opt
+  cmake --build build --target all
+  cmake --install build --config Debug
+  cd /root
+  rm -rf opentelemetry-cpp
+EOF
+
+# For the proxy wasm plugin.
+RUN <<EOF
+  set -e
+
+  # WAMR
+  BASE=/opt
+  build_dir=/var/tmp/wamr_build
+
+  # Get the WAMR source.
+  mkdir ${build_dir}
+  cd ${build_dir}
+  wget https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-1.2.1.tar.gz
+  tar zxvf WAMR-1.2.1.tar.gz
+
+  # Build WAMR.
+  cd wasm-micro-runtime-WAMR-1.2.1
+  cp core/iwasm/include/* ${BASE}/include/
+  cd product-mini/platforms/linux
+  cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=${BASE} -DWAMR_BUILD_INTERP=1 -DWAMR_BUILD_FAST_INTERP=1 -DWAMR_BUILD_JIT=0 -DWAMR_BUILD_AOT=0 -DWAMR_BUILD_SIMD=0 -DWAMR_BUILD_MULTI_MODULE=1 -DWAMR_BUILD_LIBC_WASI=0 -DWAMR_BUILD_TAIL_CALL=1 -DWAMR_DISABLE_HW_BOUND_CHECK=1 -DWAMR_BUILD_BULK_MEMORY=1 -DWAMR_BUILD_WASM_CACHE=0
+  cmake --build build
+  sudo cmake --install build
+
+  # WAMR Cleanup.
+  cd /var/tmp
+  rm -rf ${build_dir}
+EOF
+
+# Install abi checking tools.
+RUN <<EOF
+  set -e
+  mkdir -p /root/src/abi
+  cd /root/src/abi
+  git clone https://github.com/lvc/installer.git
+  cd installer
+  for i in abi-dumper abi-tracker abi-compliance-checker vtable-dumper abi-monitor
+  do
+    make install prefix=/opt target=${i}
+  done
+  cd /root
+  rm -rf src/abi
+EOF
+
+FROM fedora:44
+
+RUN <<EOF
+  set -e
+
+  dnf repolist
+  dnf -y update
+
+  # Build tools.
+  dnf -y install \
+    ccache make pkgconfig bison flex gcc-c++ clang \
+    autoconf automake libtool \
+    cmake ninja-build
+
+  # Various other tools
+  dnf -y install \
+    sudo git rpm-build distcc-server file wget openssl hwloc \
+    fmt fmt-devel pcre2-devel
+
+  # Devel packages that ATS needs
+  dnf -y install \
+    openssl-devel openssl-devel-engine expat-devel pcre-devel libcap-devel hwloc-devel libunwind-devel \
+    xz-devel libcurl-devel ncurses-devel jemalloc-devel GeoIP-devel luajit-devel brotli-devel \
+    ImageMagick-devel ImageMagick-c++-devel hiredis-devel zlib-devel libmaxminddb-devel \
+    perl-ExtUtils-MakeMaker perl-Digest-SHA perl-URI perl-IPC-Cmd perl-Pod-Html \
+    curl tcl-devel java cjose-devel protobuf-devel antlr4-cpp-runtime-devel antlr4
+
+  # lcov is used for code coverage.
+  dnf install -y lcov
+
+  # autest stuff
+  dnf -y install \
+    bpftrace python3 httpd-tools procps-ng nghttp2 nmap-ncat python3-pip \
+    python3-gunicorn python3-requests python3-devel python3-psutil telnet jq
+
+  dnf clean all
+EOF
+
+RUN pip3 install pipenv httpbin
+RUN export XDG_BIN_HOME=/opt/bin && curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Add the CI's test user. N.B: 1200 is the uid that our jenkins user is
+# configured with, so that has to be used. Otherwise there will be permissions
+# issues.
+ARG username=jenkins
+ARG uid=1200
+RUN <<EOF
+  set -e
+  useradd \
+    --home-dir /home/${username} \
+    --groups users,wheel \
+    --uid ${uid} \
+    --shell /bin/bash \
+    --create-home \
+    ${username}
+  echo "${username} ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers
+  chown -R ${username} /home/${username}
+EOF
+
+COPY --from=build /opt /opt
+
+ENV PATH="$PATH:/opt/bin"

--- a/docker/fedora44/build_boringssl_h3_tools.sh
+++ b/docker/fedora44/build_boringssl_h3_tools.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+#  Simple script to build BoringsSSL and various tools with H3 and QUIC support
+#  including quiche+BoringSSL.
+#  This probably needs to be modified based on platform.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+
+# This is a slightly modified version of:
+# https://github.com/apache/trafficserver/blob/master/tools/build_boringssl_h3_tools.sh
+#
+# This present script been modified from the latter in the following ways:
+#
+# * It doesn't run sudo since the Dockerfile will run this as root.
+#
+# * It doesn't use a mktemp since the caller sets up a temporary directory
+#   that it later removes.
+
+WORKDIR="$(pwd)"
+
+# Set these, if desired, to change these to your preferred installation
+# directory
+BASE=${BASE:-"/opt/h3-tools-boringssl"}
+MAKE="make"
+
+echo "Building boringssl H3 dependencies in ${WORKDIR}. Installation will be done in ${BASE}"
+
+CFLAGS=${CFLAGS:-"-O3 -g"}
+CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
+BORINGSSL_PATH="${BASE}/boringssl"
+NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
+
+if [ -e /etc/redhat-release ]; then
+    MAKE="gmake"
+    TMP_BORINGSSL_LIB_PATH="${BASE}/boringssl/lib64"
+    echo "+-------------------------------------------------------------------------+"
+    echo "| You probably need to run this, or something like this, for your system: |"
+    echo "|                                                                         |"
+    echo "|   sudo yum -y install libev-devel jemalloc-devel python2-devel          |"
+    echo "|   sudo yum -y install libxml2-devel c-ares-devel libevent-devel         |"
+    echo "|   sudo yum -y install jansson-devel zlib-devel systemd-devel cargo      |"
+    echo "|                                                                         |"
+    echo "| Rust may be needed too, see https://rustup.rs for the details           |"
+    echo "+-------------------------------------------------------------------------+"
+    echo
+    echo
+elif [ -e /etc/debian_version ]; then
+    TMP_BORINGSSL_LIB_PATH="${BASE}/boringssl/lib"
+    echo "+-------------------------------------------------------------------------+"
+    echo "| You probably need to run this, or something like this, for your system: |"
+    echo "|                                                                         |"
+    echo "|   sudo apt -y install libev-dev libjemalloc-dev python2-dev libxml2-dev |"
+    echo "|   sudo apt -y install libpython2-dev libc-ares-dev libsystemd-dev       |"
+    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev cargo      |"
+    echo "|                                                                         |"
+    echo "| Rust may be needed too, see https://rustup.rs for the details           |"
+    echo "+-------------------------------------------------------------------------+"
+    echo
+    echo
+fi
+
+if [ `uname -s` = "Darwin" ]; then
+    echo "+-------------------------------------------------------------------------+"
+    echo "| When building on a Mac, be aware that the Apple version of clang may    |"
+    echo "| fail to build curl due to the issue described here:                     |"
+    echo "| https://github.com/curl/curl/issues/11391#issuecomment-1623890325       |"
+    echo "+-------------------------------------------------------------------------+"
+fi
+
+if [ -z ${BORINGSSL_LIB_PATH+x} ]; then
+   BORINGSSL_LIB_PATH=${TMP_BORINGSSL_LIB_PATH:-"${BORINGSSL_PATH}/lib"}
+fi
+
+set -x
+if [ `uname -s` = "Linux" ]
+then
+  num_threads=$(nproc)
+elif [ `uname -s` = "FreeBSD" ]
+then
+  num_threads=$(sysctl -n hw.ncpu)
+else
+  # MacOS.
+  num_threads=$(sysctl -n hw.logicalcpu)
+fi
+
+# boringssl
+echo "Building boringssl..."
+
+# We need this go version.
+mkdir -p ${BASE}/go
+
+if [ `uname -m` = "arm64" -o `uname -m` = "aarch64" ]; then
+    ARCH="arm64"
+else
+    ARCH="amd64"
+fi
+
+if [ `uname -s` = "Darwin" ]; then
+    OS="darwin"
+elif [ `uname -s` = "FreeBSD" ]; then
+    OS="freebsd"
+else
+    OS="linux"
+fi
+
+go_version=1.25.10
+wget https://go.dev/dl/go${go_version}.${OS}-${ARCH}.tar.gz
+rm -rf ${BASE}/go && tar -C ${BASE} -xf go${go_version}.${OS}-${ARCH}.tar.gz
+rm go${go_version}.${OS}-${ARCH}.tar.gz
+chmod -R a+rX ${BASE}
+
+GO_BINARY_PATH=${BASE}/go/bin/go
+if [ ! -d boringssl ]; then
+  git clone https://boringssl.googlesource.com/boringssl
+  cd boringssl
+  git checkout 02bc0949e5cac0e1ee82c6f365f5a6c3cfd0cfa9
+  cd ..
+fi
+cd boringssl
+
+# un-set it for a bit.
+set +e
+BSSL_C_FLAGS="-Wdangling-pointer=0"
+GCCO=$(eval "gcc --help=warnings | grep dangling-pointer=")
+retVal=$?
+if [ $retVal -eq 1 ]; then
+    BSSL_C_FLAGS=""
+fi
+set -e
+
+# Check compiler flags before passing them to CMake. GCC errors on some
+# Clang-only -Wno-error= flags, including -Wcharacter-conversion.
+compiler_supports_flag() {
+  local compiler=$1
+  local flag=$2
+
+  echo '' | "${compiler}" "${flag}" -x c++ -c -o /dev/null - >/dev/null 2>&1
+}
+
+# Note: -Wdangling-pointer=0
+# We may have some issues with latest GCC compilers, so disabling -Wdangling-pointer=
+# Note: -UBORINGSSL_HAVE_LIBUNWIND
+#   Disable related libunwind test builds, there are some version number issues
+#   with this pkg in Ubuntu 20.04, so disable this to make sure it builds.
+BSSL_CXX_FLAGS="-Wno-error=ignored-attributes -UBORINGSSL_HAVE_LIBUNWIND"
+if compiler_supports_flag c++ -Wno-error=character-conversion; then
+  BSSL_CXX_FLAGS="-Wno-error=character-conversion ${BSSL_CXX_FLAGS}"
+fi
+
+cmake \
+  -B build-shared \
+  -DGO_EXECUTABLE=${GO_BINARY_PATH} \
+  -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS="${BSSL_CXX_FLAGS}" \
+  -DCMAKE_C_FLAGS=${BSSL_C_FLAGS} \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DBUILD_TESTING=0 \
+  -DCMAKE_THREAD_LIBS_INIT="-lpthread" \
+  -DTHREADS_PREFER_PTHREAD_FLAG=ON \
+  -DBUILD_SHARED_LIBS=1
+cmake \
+  -B build-static \
+  -DGO_EXECUTABLE=${GO_BINARY_PATH} \
+  -DCMAKE_INSTALL_PREFIX=${BASE}/boringssl \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_CXX_FLAGS="${BSSL_CXX_FLAGS}" \
+  -DCMAKE_C_FLAGS="${BSSL_C_FLAGS}" \
+  -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
+  -DBUILD_TESTING=0 \
+  -DCMAKE_THREAD_LIBS_INIT="-lpthread" \
+  -DTHREADS_PREFER_PTHREAD_FLAG=ON \
+  -DBUILD_SHARED_LIBS=0
+cmake --build build-shared -j ${num_threads}
+cmake --build build-static -j ${num_threads}
+cmake --install build-shared
+cmake --install build-static
+chmod -R a+rX ${BASE}
+
+cd ..
+
+# Build quiche
+# Steps borrowed from: https://github.com/apache/trafficserver-ci/blob/main/docker/rockylinux8/Dockerfile
+echo "Building quiche"
+QUICHE_BASE="${BASE:-/opt}/quiche"
+[ ! -d quiche ] && git clone  https://github.com/cloudflare/quiche.git
+cd quiche
+git checkout 0.23.2
+QUICHE_BSSL_PATH=${BORINGSSL_LIB_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
+mkdir -p ${QUICHE_BASE}/lib/pkgconfig
+mkdir -p ${QUICHE_BASE}/include
+cp target/release/libquiche.a ${QUICHE_BASE}/lib/
+if [ -f target/release/libquiche.so ]; then
+  cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+  # Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+  ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+fi
+cp quiche/include/quiche.h ${QUICHE_BASE}/include/
+cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
+chmod -R a+rX ${BASE}
+cd ..
+
+LDFLAGS=${LDFLAGS:-"-Wl,-rpath,${BORINGSSL_LIB_PATH}"}
+
+# Then nghttp3
+echo "Building nghttp3..."
+[ ! -d nghttp3 ] && git clone --depth 1 -b ${NGHTTP3_TAG} https://github.com/ngtcp2/nghttp3.git
+cd nghttp3
+git submodule update --init
+autoreconf -if
+./configure \
+  --prefix=${BASE} \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${BORINGSSL_LIB_PATH}/pkgconfig \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  LDFLAGS="${LDFLAGS}" \
+  --enable-lib-only
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Now ngtcp2
+echo "Building ngtcp2..."
+[ ! -d ngtcp2 ] && git clone --depth 1 -b ${NGTCP2_TAG} https://github.com/ngtcp2/ngtcp2.git
+cd ngtcp2
+git submodule update --init
+autoreconf -if
+./configure \
+  --prefix=${BASE} \
+  --with-boringssl \
+  BORINGSSL_CFLAGS="-I${BORINGSSL_PATH}/include" \
+  BORINGSSL_LIBS="-L${BORINGSSL_LIB_PATH} -lssl -lcrypto" \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig \
+  CFLAGS="${CFLAGS} -fPIC" \
+  CXXFLAGS="${CXXFLAGS} -fPIC" \
+  LDFLAGS="${LDFLAGS}" \
+  --enable-lib-only
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Then nghttp2, with support for H3
+echo "Building nghttp2 ..."
+[ ! -d nghttp2 ] && git clone --depth 1 -b ${NGHTTP2_TAG} https://github.com/nghttp2/nghttp2.git
+cd nghttp2
+git submodule update --init
+autoreconf -if
+if [ `uname -s` = "Darwin" ] || [ `uname -s` = "FreeBSD" ]
+then
+  # --enable-app requires systemd which is not available on Mac/FreeBSD.
+  ENABLE_APP=""
+else
+  ENABLE_APP="--enable-app"
+fi
+
+# Note for FreeBSD: This will not build h2load. h2load can be run on a remote machine.
+./configure \
+  --prefix=${BASE} \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig \
+  CFLAGS="${CFLAGS} -I${BORINGSSL_PATH}/include" \
+  CXXFLAGS="${CXXFLAGS} -I${BORINGSSL_PATH}/include" \
+  LDFLAGS="${LDFLAGS}" \
+  OPENSSL_LIBS="-lcrypto -lssl -L${BORINGSSL_LIB_PATH}" \
+  --enable-http3 \
+  --disable-examples \
+  ${ENABLE_APP}
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Then curl
+echo "Building curl ..."
+[ ! -d curl ] && git clone --depth 1 -b curl-8_12_1 https://github.com/curl/curl.git
+cd curl
+# On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
+# The second runs fine.
+autoreconf -fi || autoreconf -fi
+# Keep discovery on PKG_CONFIG_PATH so curl finds ngtcp2 and its BoringSSL crypto backend together.
+PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${BORINGSSL_LIB_PATH}/pkgconfig \
+./configure \
+  --prefix=${BASE} \
+  --with-openssl="${BORINGSSL_PATH}" \
+  --with-nghttp2 \
+  --with-nghttp3 \
+  --with-ngtcp2 \
+  LDFLAGS="${LDFLAGS} -L${BORINGSSL_LIB_PATH} -Wl,-rpath,${BORINGSSL_LIB_PATH}" \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}"
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..

--- a/docker/fedora44/build_openssl_h3_tools.sh
+++ b/docker/fedora44/build_openssl_h3_tools.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+#
+#  Simple script to build OpenSSL and various tools with H3 and QUIC support
+#  including quiche+OpenSSL.
+#  This probably needs to be modified based on platform.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+set -e
+
+# This is a slightly modified version of:
+# https://github.com/apache/trafficserver/blob/master/tools/build_openssl_h3_tools.sh
+#
+# This present script been modified from the latter in the following ways:
+#
+# * It doesn't run sudo since the Dockerfile will run this as root.
+#
+# * It doesn't use a mktemp since the caller sets up a temporary directory
+#   that it later removes.
+
+WORKDIR="$(pwd)"
+
+# OPENSSL_BRANCH is kept for compatibility with older local invocations.
+OPENSSL_TAG=${OPENSSL_TAG:-${OPENSSL_BRANCH:-"openssl-3.5.5"}}
+NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
+
+# Set these, if desired, to change these to your preferred installation
+# directory
+BASE=${BASE:-"/opt/h3-tools-openssl"}
+OPENSSL_BASE=${OPENSSL_BASE:-"${BASE}/openssl-quic"}
+OPENSSL_PREFIX=${OPENSSL_PREFIX:-"${OPENSSL_BASE}-${OPENSSL_TAG}"}
+MAKE="make"
+
+echo "Building OpenSSL H3 dependencies in ${WORKDIR}. Installation will be done in ${BASE}"
+
+CFLAGS=${CFLAGS:-"-O3 -g"}
+CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
+
+if [ -e /etc/redhat-release ]; then
+    MAKE="gmake"
+    echo "+-------------------------------------------------------------------------+"
+    echo "| You probably need to run this, or something like this, for your system: |"
+    echo "|                                                                         |"
+    echo "|   sudo yum -y install libev-devel jemalloc-devel python2-devel          |"
+    echo "|   sudo yum -y install libxml2-devel c-ares-devel libevent-devel         |"
+    echo "|   sudo yum -y install jansson-devel zlib-devel systemd-devel cargo      |"
+    echo "|                                                                         |"
+    echo "| Rust may be needed too, see https://rustup.rs for the details           |"
+    echo "+-------------------------------------------------------------------------+"
+    echo
+    echo
+elif [ -e /etc/debian_version ]; then
+    echo "+-------------------------------------------------------------------------+"
+    echo "| You probably need to run this, or something like this, for your system: |"
+    echo "|                                                                         |"
+    echo "|   sudo apt -y install libev-dev libjemalloc-dev python2-dev libxml2-dev |"
+    echo "|   sudo apt -y install libpython2-dev libc-ares-dev libsystemd-dev       |"
+    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev cargo      |"
+    echo "|                                                                         |"
+    echo "| Rust may be needed too, see https://rustup.rs for the details           |"
+    echo "+-------------------------------------------------------------------------+"
+    echo
+    echo
+fi
+
+if [ `uname -s` = "Darwin" ]; then
+    echo "+-------------------------------------------------------------------------+"
+    echo "| When building on a Mac, be aware that the Apple version of clang may    |"
+    echo "| fail to build curl due to the issue described here:                     |"
+    echo "| https://github.com/curl/curl/issues/11391#issuecomment-1623890325       |"
+    echo "+-------------------------------------------------------------------------+"
+fi
+
+set -x
+if [ `uname -s` = "Linux" ]
+then
+  num_threads=$(nproc)
+elif [ `uname -s` = "FreeBSD" ]
+then
+  num_threads=$(sysctl -n hw.ncpu)
+else
+  # MacOS.
+  num_threads=$(sysctl -n hw.logicalcpu)
+fi
+
+echo "Building OpenSSL with QUIC support"
+[ ! -d openssl ] && git clone -b ${OPENSSL_TAG} --depth 1 https://github.com/openssl/openssl.git openssl
+cd openssl
+./config enable-tls1_3 --prefix=${OPENSSL_PREFIX} --libdir=lib
+${MAKE} -j ${num_threads}
+${MAKE} install_sw
+chmod -R a+rX ${BASE}
+
+# The symlink target provides a more convenient path for the user while also
+# providing, in the symlink source, the precise branch of the OpenSSL build.
+ln -sf ${OPENSSL_PREFIX} ${OPENSSL_BASE}
+chmod -R a+rX ${BASE}
+cd ..
+
+# OpenSSL will install in /lib or lib64 depending upon the architecture.
+if [ -d "${OPENSSL_PREFIX}/lib" ]; then
+  OPENSSL_LIB="${OPENSSL_PREFIX}/lib"
+elif [ -d "${OPENSSL_PREFIX}/lib64" ]; then
+  OPENSSL_LIB="${OPENSSL_PREFIX}/lib64"
+else
+  echo "Could not find the OpenSSL install library directory."
+  exit 1
+fi
+LDFLAGS=${LDFLAGS:-"-Wl,-rpath,${OPENSSL_LIB}"}
+
+# Build quiche
+# Steps borrowed from: https://github.com/apache/trafficserver-ci/blob/main/docker/rockylinux8/Dockerfile
+echo "Building quiche"
+QUICHE_BASE="${BASE:-/opt}/quiche"
+[ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
+cd quiche
+git checkout 0.23.2
+
+PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
+  cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
+
+mkdir -p ${QUICHE_BASE}/lib/pkgconfig
+mkdir -p ${QUICHE_BASE}/include
+cp target/release/libquiche.a ${QUICHE_BASE}/lib/
+if [ -f target/release/libquiche.so ]; then
+  cp target/release/libquiche.so ${QUICHE_BASE}/lib/
+  # Why a link? https://github.com/cloudflare/quiche/issues/1808#issuecomment-2196233378
+  ln -sf ${QUICHE_BASE}/lib/libquiche.so ${QUICHE_BASE}/lib/libquiche.so.0
+fi
+cp quiche/include/quiche.h ${QUICHE_BASE}/include/
+cp target/release/quiche.pc ${QUICHE_BASE}/lib/pkgconfig
+chmod -R a+rX ${BASE}
+cd ..
+
+
+# Then nghttp3
+echo "Building nghttp3..."
+[ ! -d nghttp3 ] && git clone --depth 1 -b ${NGHTTP3_TAG} https://github.com/ngtcp2/nghttp3.git
+cd nghttp3
+git submodule update --init
+autoreconf -if
+./configure \
+  --prefix=${BASE} \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  LDFLAGS="${LDFLAGS}" \
+  --enable-lib-only
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Now ngtcp2
+echo "Building ngtcp2..."
+[ ! -d ngtcp2 ] && git clone --depth 1 -b ${NGTCP2_TAG} https://github.com/ngtcp2/ngtcp2.git
+cd ngtcp2
+git submodule update --init
+autoreconf -if
+./configure \
+  --prefix=${BASE} \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  LDFLAGS="${LDFLAGS}" \
+  --enable-lib-only
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Then nghttp2, with support for H3
+echo "Building nghttp2 ..."
+[ ! -d nghttp2 ] && git clone --depth 1 -b ${NGHTTP2_TAG} https://github.com/nghttp2/nghttp2.git
+cd nghttp2
+git submodule update --init
+autoreconf -if
+if [ `uname -s` = "Darwin" ] || [ `uname -s` = "FreeBSD" ]
+then
+  # --enable-app requires systemd which is not available on Mac/FreeBSD.
+  ENABLE_APP=""
+else
+  ENABLE_APP="--enable-app"
+fi
+
+# Note for FreeBSD: This will not build h2load. h2load can be run on a remote machine.
+./configure \
+  --prefix=${BASE} \
+  PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  LDFLAGS="${LDFLAGS} -L${OPENSSL_LIB}" \
+  --enable-http3 \
+  ${ENABLE_APP}
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..
+
+# Then curl
+echo "Building curl ..."
+[ ! -d curl ] && git clone --depth 1 -b curl-8_12_1 https://github.com/curl/curl.git
+cd curl
+# On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
+# The second runs fine.
+autoreconf -fi || autoreconf -fi
+# Curl's OpenSSL QUIC backend does not use ngtcp2.
+PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
+./configure \
+  --prefix=${BASE} \
+  --with-ssl=${OPENSSL_PREFIX} \
+  --with-nghttp2=${BASE} \
+  --with-nghttp3=${BASE} \
+  --with-openssl-quic \
+  --without-ngtcp2 \
+  CFLAGS="${CFLAGS}" \
+  CXXFLAGS="${CXXFLAGS}" \
+  LDFLAGS="${LDFLAGS}"
+${MAKE} -j ${num_threads}
+${MAKE} install
+chmod -R a+rX ${BASE}
+cd ..


### PR DESCRIPTION
Fedora 44 is the next CI image target for ATS, and the existing
Fedora 43-based configuration does not exercise the latest compiler,
OpenSSL, Python, and H3 dependency stack.

This adds the Fedora 44 image files with H3 helper scripts updated to
the dependency versions used by proxy-verifier. The OpenSSL toolchain
now uses official OpenSSL 3.5.5 with native QUIC, while the BoringSSL
toolchain keeps the pinned BoringSSL revision and updates only nghttp2,
ngtcp2, and nghttp3.

This also switches the runtime stage to Fedora 44 and adds the Perl
module required by the OpenSSL 3.5.5 build.