### PR TITLE
fedora:44 avoid GNU tar for source archives

### DIFF
--- a/docker/fedora44/Dockerfile
+++ b/docker/fedora44/Dockerfile
@@ -148,7 +148,7 @@ RUN <<EOF
   mkdir nlohmann-json
   cd nlohmann-json
   wget https://github.com/nlohmann/json/archive/refs/tags/v3.11.3.tar.gz
-  tar zxf v3.11.3.tar.gz
+  python3 -m tarfile -e v3.11.3.tar.gz
   cd json-3.11.3
   cmake -B build -G Ninja -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -DCMAKE_INSTALL_PREFIX=/opt -DJSON_BuildTests=OFF
   cmake --build build
@@ -159,7 +159,7 @@ RUN <<EOF
   mkdir opentelemetry-cpp
   cd opentelemetry-cpp
   wget https://github.com/open-telemetry/opentelemetry-cpp/archive/refs/tags/v1.3.0.tar.gz
-  tar zxf v1.3.0.tar.gz
+  python3 -m tarfile -e v1.3.0.tar.gz
   cd opentelemetry-cpp-1.3.0
   cmake -B build -G Ninja -DBUILD_TESTING=OFF -DWITH_EXAMPLES=OFF -DWITH_JAEGER=OFF -DWITH_OTLP=ON -DWITH_OTLP_GRPC=OFF -DWITH_OTLP_HTTP=ON -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DCMAKE_CXX_STANDARD=17 -DCMAKE_CXX_STANDARD_REQUIRED=ON -Dnlohmann_json_ROOT=/opt/ -DCMAKE_INSTALL_PREFIX=/opt
   cmake --build build --target all
@@ -180,7 +180,7 @@ RUN <<EOF
   mkdir ${build_dir}
   cd ${build_dir}
   wget https://github.com/bytecodealliance/wasm-micro-runtime/archive/refs/tags/WAMR-1.2.1.tar.gz
-  tar zxvf WAMR-1.2.1.tar.gz
+  python3 -m tarfile -e WAMR-1.2.1.tar.gz
 
   # Build WAMR.
   cd wasm-micro-runtime-WAMR-1.2.1
@@ -202,6 +202,7 @@ RUN <<EOF
   cd /root/src/abi
   git clone https://github.com/lvc/installer.git
   cd installer
+  perl -0pi -e 's{qx/tar -xf archive\.tar\.gz/;}{qx/python3 -m tarfile -e archive.tar.gz/;}' installer.pl
   for i in abi-dumper abi-tracker abi-compliance-checker vtable-dumper abi-monitor
   do
     make install prefix=/opt target=${i}

--- a/docker/fedora44/build_boringssl_h3_tools.sh
+++ b/docker/fedora44/build_boringssl_h3_tools.sh
@@ -105,6 +105,27 @@ else
   num_threads=$(sysctl -n hw.logicalcpu)
 fi
 
+extract_tarball() {
+  archive="$1"
+  destination="$2"
+
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$archive" "$destination" <<'PY'
+import sys
+import tarfile
+
+archive_path, destination = sys.argv[1:]
+with tarfile.open(archive_path) as archive:
+    try:
+        archive.extractall(destination, filter="fully_trusted")
+    except TypeError:
+        archive.extractall(destination)
+PY
+  else
+    tar -C "$destination" -xf "$archive"
+  fi
+}
+
 # boringssl
 echo "Building boringssl..."
 
@@ -126,7 +147,7 @@ else
 fi
 
 wget https://go.dev/dl/go${GO_VERSION}.${OS}-${ARCH}.tar.gz
-rm -rf ${BASE}/go && tar -C ${BASE} -xf go${GO_VERSION}.${OS}-${ARCH}.tar.gz
+rm -rf ${BASE}/go && extract_tarball go${GO_VERSION}.${OS}-${ARCH}.tar.gz ${BASE}
 rm go${GO_VERSION}.${OS}-${ARCH}.tar.gz
 chmod -R a+rX ${BASE}
 

--- a/docker/fedora44/build_boringssl_h3_tools.sh
+++ b/docker/fedora44/build_boringssl_h3_tools.sh
@@ -44,6 +44,10 @@ echo "Building boringssl H3 dependencies in ${WORKDIR}. Installation will be don
 CFLAGS=${CFLAGS:-"-O3 -g"}
 CXXFLAGS=${CXXFLAGS:-"-O3 -g"}
 BORINGSSL_PATH="${BASE}/boringssl"
+GO_VERSION=${GO_VERSION:-"1.26.2"}
+BORINGSSL_COMMIT=${BORINGSSL_COMMIT:-"c3ffc3300a9450cf8e396c7880be7c6cadc16a4a"}
+QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
+CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
 NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
 NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
 NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
@@ -67,9 +71,9 @@ elif [ -e /etc/debian_version ]; then
     echo "+-------------------------------------------------------------------------+"
     echo "| You probably need to run this, or something like this, for your system: |"
     echo "|                                                                         |"
-    echo "|   sudo apt -y install libev-dev libjemalloc-dev python2-dev libxml2-dev |"
-    echo "|   sudo apt -y install libpython2-dev libc-ares-dev libsystemd-dev       |"
-    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev cargo      |"
+    echo "|   sudo apt -y install libev-dev libjemalloc-dev python3-dev libxml2-dev |"
+    echo "|   sudo apt -y install libpython3-dev libc-ares-dev libsystemd-dev       |"
+    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev libpsl-dev |"
     echo "|                                                                         |"
     echo "| Rust may be needed too, see https://rustup.rs for the details           |"
     echo "+-------------------------------------------------------------------------+"
@@ -121,17 +125,16 @@ else
     OS="linux"
 fi
 
-go_version=1.25.10
-wget https://go.dev/dl/go${go_version}.${OS}-${ARCH}.tar.gz
-rm -rf ${BASE}/go && tar -C ${BASE} -xf go${go_version}.${OS}-${ARCH}.tar.gz
-rm go${go_version}.${OS}-${ARCH}.tar.gz
+wget https://go.dev/dl/go${GO_VERSION}.${OS}-${ARCH}.tar.gz
+rm -rf ${BASE}/go && tar -C ${BASE} -xf go${GO_VERSION}.${OS}-${ARCH}.tar.gz
+rm go${GO_VERSION}.${OS}-${ARCH}.tar.gz
 chmod -R a+rX ${BASE}
 
 GO_BINARY_PATH=${BASE}/go/bin/go
 if [ ! -d boringssl ]; then
   git clone https://boringssl.googlesource.com/boringssl
   cd boringssl
-  git checkout 02bc0949e5cac0e1ee82c6f365f5a6c3cfd0cfa9
+  git checkout ${BORINGSSL_COMMIT}
   cd ..
 fi
 cd boringssl
@@ -203,7 +206,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone  https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.23.2
+git checkout ${QUICHE_TAG}
 QUICHE_BSSL_PATH=${BORINGSSL_LIB_PATH} QUICHE_BSSL_LINK_KIND=dylib cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog
 mkdir -p ${QUICHE_BASE}/lib/pkgconfig
 mkdir -p ${QUICHE_BASE}/include
@@ -291,7 +294,7 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_12_1 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b ${CURL_TAG} https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.

--- a/docker/fedora44/build_openssl_h3_tools.sh
+++ b/docker/fedora44/build_openssl_h3_tools.sh
@@ -36,6 +36,8 @@ WORKDIR="$(pwd)"
 
 # OPENSSL_BRANCH is kept for compatibility with older local invocations.
 OPENSSL_TAG=${OPENSSL_TAG:-${OPENSSL_BRANCH:-"openssl-3.5.5"}}
+QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
+CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
 NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
 NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
 NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
@@ -69,9 +71,9 @@ elif [ -e /etc/debian_version ]; then
     echo "+-------------------------------------------------------------------------+"
     echo "| You probably need to run this, or something like this, for your system: |"
     echo "|                                                                         |"
-    echo "|   sudo apt -y install libev-dev libjemalloc-dev python2-dev libxml2-dev |"
-    echo "|   sudo apt -y install libpython2-dev libc-ares-dev libsystemd-dev       |"
-    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev cargo      |"
+    echo "|   sudo apt -y install libev-dev libjemalloc-dev python3-dev libxml2-dev |"
+    echo "|   sudo apt -y install libpython3-dev libc-ares-dev libsystemd-dev       |"
+    echo "|   sudo apt -y install libevent-dev libjansson-dev zlib1g-dev libpsl-dev |"
     echo "|                                                                         |"
     echo "| Rust may be needed too, see https://rustup.rs for the details           |"
     echo "+-------------------------------------------------------------------------+"
@@ -130,7 +132,7 @@ echo "Building quiche"
 QUICHE_BASE="${BASE:-/opt}/quiche"
 [ ! -d quiche ] && git clone https://github.com/cloudflare/quiche.git
 cd quiche
-git checkout 0.23.2
+git checkout ${QUICHE_TAG}
 
 PKG_CONFIG_PATH="$OPENSSL_LIB"/pkgconfig LD_LIBRARY_PATH="$OPENSSL_LIB" \
   cargo build -j4 --package quiche --release --features ffi,pkg-config-meta,qlog,openssl
@@ -175,6 +177,7 @@ git submodule update --init
 autoreconf -if
 ./configure \
   --prefix=${BASE} \
+  --with-openssl \
   PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
   CFLAGS="${CFLAGS}" \
   CXXFLAGS="${CXXFLAGS}" \
@@ -215,20 +218,19 @@ cd ..
 
 # Then curl
 echo "Building curl ..."
-[ ! -d curl ] && git clone --depth 1 -b curl-8_12_1 https://github.com/curl/curl.git
+[ ! -d curl ] && git clone --depth 1 -b ${CURL_TAG} https://github.com/curl/curl.git
 cd curl
 # On mac autoreconf fails on the first attempt with an issue finding ltmain.sh.
 # The second runs fine.
 autoreconf -fi || autoreconf -fi
-# Curl's OpenSSL QUIC backend does not use ngtcp2.
+# Curl 8.20 uses ngtcp2 for its OpenSSL-backed HTTP/3 transport.
 PKG_CONFIG_PATH=${BASE}/lib/pkgconfig:${OPENSSL_LIB}/pkgconfig \
 ./configure \
   --prefix=${BASE} \
   --with-ssl=${OPENSSL_PREFIX} \
   --with-nghttp2=${BASE} \
   --with-nghttp3=${BASE} \
-  --with-openssl-quic \
-  --without-ngtcp2 \
+  --with-ngtcp2=${BASE} \
   CFLAGS="${CFLAGS}" \
   CXXFLAGS="${CXXFLAGS}" \
   LDFLAGS="${LDFLAGS}"


### PR DESCRIPTION
Fedora 44 GNU tar fails to extract downloaded source archives on
the older controller Docker host, returning ENOSYS while creating
files under overlay2. The same image builds on newer Docker hosts,
so the Fedora image needs to avoid that host-specific tar path.

This uses Python's tarfile support for the downloaded Go, json,
OpenTelemetry, WAMR, and ABI tool archives while keeping tar as the
fallback for non-Python environments in the standalone BoringSSL
helper.

