### PR TITLE
fedora:44 update h3 dependency tags

### DIFF
--- a/docker/fedora44/build_boringssl_h3_tools.sh
+++ b/docker/fedora44/build_boringssl_h3_tools.sh
@@ -49,8 +49,8 @@ BORINGSSL_COMMIT=${BORINGSSL_COMMIT:-"c3ffc3300a9450cf8e396c7880be7c6cadc16a4a"}
 QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
 CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
 NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
-NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
-NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.22.1"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.69.0"}
 
 if [ -e /etc/redhat-release ]; then
     MAKE="gmake"
@@ -150,7 +150,7 @@ fi
 set -e
 
 # Check compiler flags before passing them to CMake. GCC errors on some
-# Clang-only -Wno-error= flags, including -Wcharacter-conversion.
+# Clang-only -Wno-error flags, including -Wno-error=character-conversion.
 compiler_supports_flag() {
   local compiler=$1
   local flag=$2

--- a/docker/fedora44/build_openssl_h3_tools.sh
+++ b/docker/fedora44/build_openssl_h3_tools.sh
@@ -35,12 +35,12 @@ set -e
 WORKDIR="$(pwd)"
 
 # OPENSSL_BRANCH is kept for compatibility with older local invocations.
-OPENSSL_TAG=${OPENSSL_TAG:-${OPENSSL_BRANCH:-"openssl-3.5.5"}}
+OPENSSL_TAG=${OPENSSL_TAG:-${OPENSSL_BRANCH:-"openssl-3.5.6"}}
 QUICHE_TAG=${QUICHE_TAG:-"0.28.0"}
 CURL_TAG=${CURL_TAG:-"curl-8_20_0"}
 NGHTTP3_TAG=${NGHTTP3_TAG:-"v1.15.0"}
-NGTCP2_TAG=${NGTCP2_TAG:-"v1.21.0"}
-NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.68.0"}
+NGTCP2_TAG=${NGTCP2_TAG:-"v1.22.1"}
+NGHTTP2_TAG=${NGHTTP2_TAG:-"v1.69.0"}
 
 # Set these, if desired, to change these to your preferred installation
 # directory
@@ -115,7 +115,7 @@ ln -sf ${OPENSSL_PREFIX} ${OPENSSL_BASE}
 chmod -R a+rX ${BASE}
 cd ..
 
-# OpenSSL will install in /lib or lib64 depending upon the architecture.
+# OpenSSL is configured to install its libraries in lib.
 if [ -d "${OPENSSL_PREFIX}/lib" ]; then
   OPENSSL_LIB="${OPENSSL_PREFIX}/lib"
 elif [ -d "${OPENSSL_PREFIX}/lib64" ]; then


### PR DESCRIPTION
The Fedora 44 H3 build scripts should track the same current dependency
versions as the Traffic Server helper scripts. Some previous defaults were
older than the latest available releases and could accidentally regress the
controller-built toolchain.

This updates the Fedora 44 BoringSSL and OpenSSL helper defaults to the
latest checked tags for OpenSSL 3.5.x, ngtcp2, and nghttp2 while keeping
curl and nghttp3 at their current latest tags.

