### PR TITLE
Revert "Update autest.pipeline"

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'ci.trafficserver.apache.org/ats/fedora:42'
+      image 'ci.trafficserver.apache.org/ats/fedora:44'
       registryUrl 'https://ci.trafficserver.apache.org/'
       args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
       label 'docker'


### PR DESCRIPTION
Let's try fedora:44 again.

This reverts commit 887984e6a43f8df30e20ef7404c3932252d7e795.