### PR TITLE
Revert "Revert "Update autest.pipeline""

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -1,7 +1,7 @@
 pipeline {
   agent {
     docker {
-      image 'ci.trafficserver.apache.org/ats/fedora:44'
+      image 'ci.trafficserver.apache.org/ats/fedora:42'
       registryUrl 'https://ci.trafficserver.apache.org/'
       args '--init --cap-add=SYS_PTRACE --network=host -v ${HOME}/ccache:/tmp/ccache:rw'
       label 'docker'


### PR DESCRIPTION
Reverts apache/trafficserver-ci#430

Have to put fedora:42 back because sharding on remap_acl/remap_acl_yaml doesn't work in fedora:44.