### PR TITLE
Trust mounted Git mirror repositories

### DIFF
--- a/github-mirror/README.md
+++ b/github-mirror/README.md
@@ -647,10 +647,15 @@ Jenkins cannot clone from HTTPS:
 - Verify ATS remap order.
 - Verify `/mirror/` points to `http://localhost:9417/mirror/`.
 - Verify the smart HTTP service is healthy.
+- If the service logs say `detected dubious ownership`, rebuild the current
+  image so Git trusts the bind-mounted mirror repositories.
 - Verify the public URL:
 
   ```bash
   sudo systemctl status github-mirror-smart-http.service
+  cd /opt/trafficserver-ci/github-mirror/httpd
+  sudo docker-compose build
+  sudo systemctl restart github-mirror-smart-http.service
   sudo docker exec github-mirror-smart-http httpd -t
   git ls-remote https://ci.trafficserver.apache.org/mirror/trafficserver.git refs/heads/master
   ```

--- a/github-mirror/httpd/Dockerfile
+++ b/github-mirror/httpd/Dockerfile
@@ -6,6 +6,9 @@ RUN apt-get update \
     git \
   && rm -rf /var/lib/apt/lists/*
 
+RUN git config --system --add safe.directory /usr/local/apache2/mirror/trafficserver.git \
+  && git config --system --add safe.directory /usr/local/apache2/mirror/trafficserver-ci.git
+
 COPY mirror.conf /usr/local/apache2/conf/extra/github-mirror.conf
 
 RUN printf '\nInclude conf/extra/github-mirror.conf\n' >> /usr/local/apache2/conf/httpd.conf


### PR DESCRIPTION
The smart HTTP container serves host-owned bare repositories from a
read-only bind mount. Git rejects those repositories as dubious when the
container UID does not match the host mirror owner, which makes direct
smart HTTP fetches fail with HTTP 500.

This records the expected mirror paths as system safe directories in the
container image. The troubleshooting notes also point operators at the
same failure mode so an old image can be rebuilt quickly during rollout.