### PR TITLE
Fix GitHub PR pipeline refspec syntax

### DIFF
--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -46,7 +46,7 @@ pipeline {
             branches: [[name: sha1]],
             extensions: [
               [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-              // We have to set an idenity for the merge step because Git requires
+              // We have to set an identity for the merge step because Git requires
               // the user.name and user.email to be set to do a merge.
               [$class: "UserIdentity",
                 name: "ATS CI User",
@@ -62,7 +62,7 @@ pipeline {
               ],
             ],
             userRemoteConfigs: [[url: github_url,
-                refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
           sh '''#!/bin/bash
             set -x
 

--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/clang-analyzer.pipeline
+++ b/jenkins/github/clang-analyzer.pipeline
@@ -16,7 +16,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -32,7 +32,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -17,7 +17,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -33,7 +33,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/format.pipeline
+++ b/jenkins/github/format.pipeline
@@ -17,7 +17,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -33,7 +33,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -9,7 +9,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -25,7 +25,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/osx.pipeline
+++ b/jenkins/github/osx.pipeline
@@ -9,7 +9,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -25,7 +25,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                         set -x
 

--- a/jenkins/github/rat.pipeline
+++ b/jenkins/github/rat.pipeline
@@ -17,7 +17,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -33,7 +33,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/rocky-asan.pipeline
+++ b/jenkins/github/rocky-asan.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 

--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -20,7 +20,7 @@ pipeline {
                         branches: [[name: sha1]],
                         extensions: [
                             [$class: 'CloneOption', honorRefspec: true, timeout: 20],
-                            // We have to set an idenity for the merge step because Git requires
+                            // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",
                                 name: "ATS CI User",
@@ -36,7 +36,7 @@ pipeline {
                             ],
                         ],
                         userRemoteConfigs: [[url: github_url,
-                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]])
+                            refspec: "+refs/heads/${GITHUB_PR_TARGET_BRANCH}:refs/remotes/origin/${GITHUB_PR_TARGET_BRANCH} +refs/pull/${GITHUB_PR_NUMBER}/head:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/head +refs/pull/${GITHUB_PR_NUMBER}/merge:refs/remotes/origin/pr/${GITHUB_PR_NUMBER}/merge"]]])
                     sh '''#!/bin/bash
                             set -x
 


### PR DESCRIPTION
The narrowed PR refspec change left the GitSCM checkout map one closing
bracket short in every GitHub PR child pipeline. Jenkins fails while
parsing those pipeline scripts, so affected PR jobs stop before they can
run any build steps.

This restores the missing list/map close on each userRemoteConfigs entry
and fixes the repeated identity comment typo while touching the same
checkout block.