### PR TITLE
Raise smart mirror Git backend timeout

### DIFF
--- a/github-mirror/README.md
+++ b/github-mirror/README.md
@@ -669,6 +669,17 @@ Jenkins fetches look like dumb HTTP:
   sudo tail -n 100 /var/log/github-mirror-smart-http/access_log
   ```
 
+Jenkins fetches fail with HTTP 502 after about 60 seconds:
+
+- Rebuild and restart the current smart HTTP image. The supported config gives
+  `git-upload-pack` more time to generate large packs during CI fanout.
+
+  ```bash
+  cd /opt/trafficserver-ci/github-mirror/httpd
+  sudo docker-compose build
+  sudo systemctl restart github-mirror-smart-http.service
+  ```
+
 Docker hosts cannot reach the mirror:
 
 ```bash

--- a/github-mirror/httpd/mirror.conf
+++ b/github-mirror/httpd/mirror.conf
@@ -11,6 +11,11 @@
 SetEnv GIT_PROJECT_ROOT /usr/local/apache2/mirror
 SetEnv GIT_HTTP_EXPORT_ALL 1
 
+# During CI fanout, git-upload-pack can spend more than httpd's default
+# 60 seconds generating a large pack before it writes the first response bytes.
+Timeout 600
+CGIDScriptTimeout 600
+
 CustomLog "logs/access_log" combined
 
 ScriptAlias /mirror/ /usr/lib/git-core/git-http-backend/


### PR DESCRIPTION
CI fanout can ask the smart HTTP mirror to generate many large Git packs at
once. The default httpd CGI timeout is 60 seconds, which can kill a
queued git-upload-pack before it writes response bytes and surface to
Jenkins as an HTTP 502 checkout failure.

This gives git-http-backend a longer timeout budget in the smart mirror
container. The troubleshooting notes also call out the 60-second 502
signature so operators know to rebuild and restart the image during
rollout.