### PR TITLE
Use shallow mirror checkouts in Jenkins

### DIFF
--- a/github-mirror/README.md
+++ b/github-mirror/README.md
@@ -541,8 +541,21 @@ The repo-managed PR pipeline scripts fetch:
 - only the current PR's `refs/pull/<number>/head`;
 - only the current PR's `refs/pull/<number>/merge`.
 
-They also use `CloneOption(honorRefspec: true, timeout: 20)` so Jenkins does
-not fan out a wildcard PR ref fetch to every child job.
+They also use
+`CloneOption(honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20)`
+so Jenkins does not fan out a wildcard PR ref fetch to every child job.
+
+The child jobs intentionally combine narrow refspecs with shallow, no-tags
+checkouts. The refspec controls which refs Jenkins asks the mirror for; the
+shallow checkout controls how much reachable commit history Git transfers for
+those refs. `noTags: true` keeps Jenkins from pulling extra tag-reachable
+history that the builds do not need.
+
+PR jobs use `depth: 1000` because they still run Jenkins' local
+`PreBuildMerge`. That depth must be high enough for Git to find the merge base
+between the PR head and the target branch. If the depth is too low, checkout
+should fail during the local merge with shallow-history or missing-ancestor
+errors. Raise the depth before disabling shallow clone globally.
 
 During the temporary cron rollout, set the top-level PR job quiet period to at
 least 90 seconds. Once the webhook is live and verified, the quiet period can
@@ -550,7 +563,10 @@ be removed or reduced.
 
 For branch jobs, configure the top-level branch jobs' `GITHUB_URL` parameter to
 the same ATS mirror URL. Child jobs will receive that value from the fanout job.
-Branch jobs continue using normal branch checkouts from the mirror URL.
+Branch jobs use shallow, no-tags checkouts with `depth: 1000`. Normal branch
+tip builds should have enough history. A manually requested old SHA outside the
+shallow window should fail fast instead of falling back to a large full-history
+fetch.
 
 ## Migrating An Existing Controller
 

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -47,8 +47,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -62,7 +65,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/cache-tests.pipeline
+++ b/jenkins/branch/cache-tests.pipeline
@@ -46,7 +46,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/clang_analyzer.pipeline
+++ b/jenkins/branch/clang_analyzer.pipeline
@@ -32,8 +32,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -47,7 +50,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/cmake.pipeline
+++ b/jenkins/branch/cmake.pipeline
@@ -35,8 +35,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -50,7 +53,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -34,8 +34,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -49,7 +52,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/coverity.pipeline
+++ b/jenkins/branch/coverity.pipeline
@@ -16,8 +16,11 @@ pipeline {
 		stage('Initialization') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					sh '''#!/bin/bash
@@ -25,7 +28,14 @@ pipeline {
 						rm -rf *
 						set -x
 					'''
-					git 'https://ci.trafficserver.apache.org/mirror/trafficserver.git'
+					checkout([$class: 'GitSCM',
+						branches: [[name: env.GITHUB_BRANCH ? "*/${env.GITHUB_BRANCH}" : '*/master']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver.git']],
+						// Branch builds normally checkout the current branch tip. If a manually
+						// requested SHA is older than this shallow depth, checkout should fail fast
+						// instead of falling back to a large full-history fetch.
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
+					])
 					sh '''#!/bin/bash
 						set +x
 						source /opt/rh/gcc-toolset-11/enable

--- a/jenkins/branch/docs.pipeline
+++ b/jenkins/branch/docs.pipeline
@@ -28,8 +28,11 @@ pipeline {
 				}
 
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 
 				dir('src') {
@@ -44,7 +47,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/format.pipeline
+++ b/jenkins/branch/format.pipeline
@@ -30,8 +30,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -45,7 +48,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/freebsd.pipeline
+++ b/jenkins/branch/freebsd.pipeline
@@ -5,8 +5,11 @@ pipeline {
 			steps {
 				echo 'Starting Clone'
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -18,7 +21,10 @@ pipeline {
 						checkout([$class: 'GitSCM',
 							branches: [[name: branch]],
 							userRemoteConfigs: [[url: env.GITHUB_URL]],
-							extensions: [[$class: 'CloneOption', timeout: 10]],
+							// Branch builds normally checkout the current branch tip. If a manually
+							// requested SHA is older than this shallow depth, checkout should fail fast
+							// instead of falling back to a large full-history fetch.
+							extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]],
 						])
 					}
 				}

--- a/jenkins/branch/in_tree.pipeline
+++ b/jenkins/branch/in_tree.pipeline
@@ -35,8 +35,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -50,7 +53,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/os_build.pipeline
+++ b/jenkins/branch/os_build.pipeline
@@ -27,8 +27,11 @@ pipeline {
 			steps {
 				echo 'Starting Clone'
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -42,7 +45,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/osx-m1.pipeline
+++ b/jenkins/branch/osx-m1.pipeline
@@ -5,8 +5,11 @@ pipeline {
 			steps {
 				echo 'Starting Clone'
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -18,7 +21,10 @@ pipeline {
 						checkout([$class: 'GitSCM',
 							branches: [[name: branch]],
 							userRemoteConfigs: [[url: env.GITHUB_URL]],
-							extensions: [[$class: 'CloneOption', timeout: 10]],
+							// Branch builds normally checkout the current branch tip. If a manually
+							// requested SHA is older than this shallow depth, checkout should fail fast
+							// instead of falling back to a large full-history fetch.
+							extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]],
 						])
 				  }
 				}

--- a/jenkins/branch/osx.pipeline
+++ b/jenkins/branch/osx.pipeline
@@ -5,8 +5,11 @@ pipeline {
 			steps {
 				echo 'Starting Clone'
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -18,7 +21,10 @@ pipeline {
 						checkout([$class: 'GitSCM',
 							branches: [[name: branch]],
 							userRemoteConfigs: [[url: env.GITHUB_URL]],
-							extensions: [[$class: 'CloneOption', timeout: 10]],
+							// Branch builds normally checkout the current branch tip. If a manually
+							// requested SHA is older than this shallow depth, checkout should fail fast
+							// instead of falling back to a large full-history fetch.
+							extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]],
 						])
 				  }
 				}

--- a/jenkins/branch/out_of_tree.pipeline
+++ b/jenkins/branch/out_of_tree.pipeline
@@ -35,8 +35,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -50,7 +53,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -35,8 +35,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -50,7 +53,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/branch/rat.pipeline
+++ b/jenkins/branch/rat.pipeline
@@ -32,8 +32,11 @@ pipeline {
 		stage('Clone') {
 			steps {
 				dir('ci') {
-					git url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git',
-						branch: 'main'
+					checkout([$class: 'GitSCM',
+						branches: [[name: 'main']],
+						userRemoteConfigs: [[url: 'https://ci.trafficserver.apache.org/mirror/trafficserver-ci.git']],
+						extensions: [[$class: 'CloneOption', shallow: true, depth: 10, noTags: true, timeout: 10]]
+					])
 				}
 				dir('src') {
 					script {
@@ -47,7 +50,10 @@ pipeline {
 								checkout([$class: 'GitSCM',
 									branches: [[name: branch]],
 									userRemoteConfigs: [[url: env.GITHUB_URL]],
-									extensions: [[$class: 'CloneOption', timeout: 10]]
+									// Branch builds normally checkout the current branch tip. If a manually
+									// requested SHA is older than this shallow depth, checkout should fail fast
+									// instead of falling back to a large full-history fetch.
+									extensions: [[$class: 'CloneOption', shallow: true, depth: 1000, noTags: true, timeout: 10]]
 								])
 							}
 						}

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -45,7 +45,10 @@ pipeline {
           checkout([$class: 'GitSCM',
             branches: [[name: sha1]],
             extensions: [
-              [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+              // Keep this depth high enough for PreBuildMerge to find the merge base
+              // between the PR head and target branch. If it is too low, checkout will
+              // fail during the local merge with shallow-history / missing-ancestor errors.
+              [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
               // We have to set an identity for the merge step because Git requires
               // the user.name and user.email to be set to do a merge.
               [$class: "UserIdentity",

--- a/jenkins/github/centos.pipeline
+++ b/jenkins/github/centos.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/clang-analyzer.pipeline
+++ b/jenkins/github/clang-analyzer.pipeline
@@ -15,7 +15,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/debian.pipeline
+++ b/jenkins/github/debian.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/docs.pipeline
+++ b/jenkins/github/docs.pipeline
@@ -16,7 +16,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/fedora.pipeline
+++ b/jenkins/github/fedora.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/format.pipeline
+++ b/jenkins/github/format.pipeline
@@ -16,7 +16,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -8,7 +8,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/osx.pipeline
+++ b/jenkins/github/osx.pipeline
@@ -8,7 +8,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/rat.pipeline
+++ b/jenkins/github/rat.pipeline
@@ -16,7 +16,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/rocky-asan.pipeline
+++ b/jenkins/github/rocky-asan.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/rocky.pipeline
+++ b/jenkins/github/rocky.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",

--- a/jenkins/github/ubuntu.pipeline
+++ b/jenkins/github/ubuntu.pipeline
@@ -19,7 +19,10 @@ pipeline {
                     checkout([$class: 'GitSCM',
                         branches: [[name: sha1]],
                         extensions: [
-                            [$class: 'CloneOption', honorRefspec: true, timeout: 20],
+                            // Keep this depth high enough for PreBuildMerge to find the merge base
+                            // between the PR head and target branch. If it is too low, checkout will
+                            // fail during the local merge with shallow-history / missing-ancestor errors.
+                            [$class: 'CloneOption', honorRefspec: true, shallow: true, depth: 1000, noTags: true, timeout: 20],
                             // We have to set an identity for the merge step because Git requires
                             // the user.name and user.email to be set to do a merge.
                             [$class: "UserIdentity",


### PR DESCRIPTION
Fresh CI workspaces still transfer a large amount of Git history even when
Jenkins fetches from the controller mirror. Narrow PR refspecs avoid fetching
unrelated refs, but full-depth checkouts can still pull most of the ATS object
history and slow down PR fanout and branch builds.

This makes PR and branch source checkouts shallow and no-tags by default.
PR jobs keep honorRefspec and use depth 1000 so PreBuildMerge can still find
the merge base in normal cases, while branch jobs fail fast if asked to build
an older SHA outside the shallow window.