### PR TITLE
Support legacy github-mirror Compose

### DIFF
--- a/github-mirror/.dockerignore
+++ b/github-mirror/.dockerignore
@@ -1,0 +1,2 @@
+.env
+config/github-mirror-webhook.env

--- a/github-mirror/docker-compose.yml
+++ b/github-mirror/docker-compose.yml
@@ -1,3 +1,5 @@
+version: '3'
+
 services:
   github-mirror:
     build:
@@ -10,7 +12,7 @@ services:
     ports:
       - "127.0.0.1:9419:9419"
     volumes:
-      - "${MIRROR_ROOT:-/home/mirror}:/home/mirror:rw"
+      - "${MIRROR_ROOT}:/home/mirror:rw"
       - ".:/opt/github-mirror:ro"
     env_file:
       - ./config/github-mirror-webhook.env
@@ -31,14 +33,14 @@ services:
     ports:
       - "127.0.0.1:9417:80"
     volumes:
-      - "${MIRROR_ROOT:-/home/mirror}:/usr/local/apache2/mirror:ro"
+      - "${MIRROR_ROOT}:/usr/local/apache2/mirror:ro"
       - /var/log/github-mirror-smart-http:/usr/local/apache2/logs
 
   github-mirror-fallback:
     image: trafficserver/github-mirror-webhook:latest
     user: "${MIRROR_UID}:${MIRROR_GID}"
     volumes:
-      - "${MIRROR_ROOT:-/home/mirror}:/home/mirror:rw"
+      - "${MIRROR_ROOT}:/home/mirror:rw"
       - ".:/opt/github-mirror:ro"
     environment:
       MIRROR_ROOT: "/home/mirror"


### PR DESCRIPTION
The controller still uses legacy docker-compose 1.25, which rejects Compose
files without an explicit version and does not support default-value
interpolation in bind mount strings. The new /opt/github-mirror installer hit
that incompatibility during rollout.

This keeps the Compose file compatible with the controller by restoring the
version field and relying on the installer-generated .env file for MIRROR_ROOT.
This also excludes the installed webhook secret from future Docker build
contexts.