### PR TITLE
Parallelize FreeBSD PR builds

### DIFF
--- a/jenkins/github/freebsd.pipeline
+++ b/jenkins/github/freebsd.pipeline
@@ -62,7 +62,7 @@ pipeline {
                         if [ -d cmake ]
                         then
                             cmake -B build --preset ci-freebsd
-                            cmake --build build -v
+                            cmake --build build -j3 -v
                         else
                             # Pre 10.x branches only support autotools.
                             autoreconf -fiv


### PR DESCRIPTION
FreeBSD PR builds use the Unix Makefiles generator, so omitting a job
count leaves the full CMake build serial. Clean builds consequently take
roughly 45 minutes.

This patch addresses the delay by using three parallel jobs, matching
the existing FreeBSD branch pipeline and autotools fallback.