### PR TITLE
Support Uranium and AuTest CI

### DIFF
--- a/jenkins/bin/quiche.sh
+++ b/jenkins/bin/quiche.sh
@@ -40,7 +40,11 @@ cd "${WORKSPACE}/src"
 presetpath="../ci/jenkins/branch/CMakePresets.json"
 [ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
 
-cmake -B build --preset branch-quiche-on-${SSL_FLAVOR}
+cmake_args=()
+if [ -x tests/urtest.sh ]; then
+  cmake_args+=("-DURTEST_SANDBOX=/tmp/sandbox")
+fi
+cmake -B build --preset branch-quiche-on-${SSL_FLAVOR} "${cmake_args[@]}"
 cmake --build build -j${NPROC} -v
 cmake --install build
 

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -99,7 +99,16 @@ pipeline {
 							presetpath="../ci/jenkins/branch/CMakePresets.json"
 							[ -f "${presetpath}" ] && cp -f "${presetpath}" .
 
-							cmake -B build --preset ${CMAKE_PRESET}
+							cmake_args=()
+							if [ -x tests/urtest.sh ]; then
+								case "${CMAKE_PRESET}" in
+									branch-autest) CMAKE_PRESET="branch-urtest" ;;
+									branch-autest-uds) CMAKE_PRESET="branch-urtest-uds" ;;
+								esac
+								cmake_args+=("-DURTEST_SANDBOX=/tmp/sandbox")
+							fi
+							echo "Using CMake preset ${CMAKE_PRESET}."
+							cmake -B build --preset "${CMAKE_PRESET}" "${cmake_args[@]}"
 							cmake --build build -j${NPROC} -v
 							cmake --install build -v
 
@@ -129,7 +138,7 @@ pipeline {
 
 		stage('AuTest') {
 			steps {
-				echo 'Starting AuTest'
+				echo 'Starting test suite'
 				dir('src/tests') {
 					sh '''#!/bin/bash -x
 						set +e
@@ -140,48 +149,57 @@ pipeline {
 						export_dir="${WORKSPACE}/output/${GITHUB_BRANCH}"
 						mkdir -p ${export_dir}
 
-						autest_args=""
-						testsall=( $( find . -iname "*.test.py" | awk -F'/' '{print $NF}' | awk -F'.' '{print $1}' ) )
-
-						if [ -d ../cmake ]
-						then
+						test_failed=0
+						test_suite="Uranium"
+						if [ -x ../build/tests/urtest.sh ]; then
 							cd ../build/tests
-							pipenv install
-							autest_args="--sandbox /tmp/sandbox"
+							./urtest.sh --no-run-in-docker -n 2 || test_failed=1
 						else
-							autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
+							test_suite="AuTest"
+							autest_args=""
+							testsall=( $( find . -iname "*.test.py" | awk -F'/' '{print $NF}' | awk -F'.' '{print $1}' ) )
+
+							if [ -d ../cmake ]
+							then
+								cd ../build/tests
+								pipenv install
+								autest_args="--sandbox /tmp/sandbox"
+							else
+								autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
+							fi
+
+							if [ ${SHARDCNT} -le 0 ]; then
+								./autest.sh ${autest_args} || test_failed=1
+							else
+								testsall=( $(
+									for el in  "${testsall[@]}" ; do
+										echo $el
+									done | sort) )
+								ntests=${#testsall[@]}
+
+								shardsize=$((${ntests} / ${SHARDCNT}))
+								[ 0 -ne $((${ntests} % ${shardsize})) ] && shardsize=$((${shardsize} + 1))
+								shardbeg=$((${shardsize} * ${SHARD}))
+								sliced=${testsall[@]:${shardbeg}:${shardsize}}
+								./autest.sh ${autest_args} -f ${sliced[@]} || test_failed=1
+							fi
 						fi
 
-						autest_failed=0
-						if [ ${SHARDCNT} -le 0 ]; then
-							./autest.sh ${autest_args} || autest_failed=1
-						else
-							testsall=( $(
-								for el in  "${testsall[@]}" ; do
-									echo $el
-								done | sort) )
-							ntests=${#testsall[@]}
-
-							shardsize=$((${ntests} / ${SHARDCNT}))
-							[ 0 -ne $((${ntests} % ${shardsize})) ] && shardsize=$((${shardsize} + 1))
-							shardbeg=$((${shardsize} * ${SHARD}))
-							sliced=${testsall[@]:${shardbeg}:${shardsize}}
-							./autest.sh ${autest_args} -f ${sliced[@]} || autest_failed=1
-						fi
-
-						if [ -n "$(ls -A /tmp/sandbox/)" ]; then
+						if [ ! -d /tmp/sandbox/ ]; then
+							# No sandbox. Probably a catastrophic failure, like an exception,
+							# that prevented execution and the creation of a sandbox.
+							echo "${test_suite} execution fundamentally failed. No tests were run."
+							touch ${export_dir}/Autest_failures
+							sudo chmod -R 777 ${WORKSPACE}
+							exit 1
+						elif [ ${test_failed} -ne 0 ] ||
+							{ [ "${test_suite}" = "AuTest" ] && [ -n "$(ls -A /tmp/sandbox/)" ]; }; then
+							echo "${test_suite} tests failed."
 							touch ${export_dir}/Autest_failures
 							cp -rf /tmp/sandbox/ "${export_dir}"
 							# Remove socket files so they don't break archiveArtifacts.
 							find "${export_dir}" -type s -delete
 							ls "${export_dir}"
-							sudo chmod -R 777 ${WORKSPACE}
-							exit 1
-						elif [ ${autest_failed} -ne 0 ]; then
-							# No sandbox. Probably a catestrophic failure, like an exception,
-							# that prevented execution and the creation of a sandbox.
-							echo "AuTest failed."
-							touch ${export_dir}/Autest_failures
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						else

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -95,7 +95,11 @@ pipeline {
 							presetpath="../ci/jenkins/branch/CMakePresets.json"
 							[ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .
 
-							cmake -B build --preset branch-coverage
+							cmake_args=()
+							if [ -x tests/urtest.sh ]; then
+								cmake_args+=("-DURTEST_SANDBOX=/tmp/sandbox")
+							fi
+							cmake -B build --preset branch-coverage "${cmake_args[@]}"
 							cmake --build build -j${NPROC} -v
 							cmake --install build -v
 
@@ -176,7 +180,7 @@ pipeline {
 						/tmp/ats/bin/traffic_server -K -R 3
 					 '''
 				}
-				echo 'Starting AuTest'
+				echo 'Starting end-to-end tests'
 				dir('src/tests') {
 					sh '''#!/bin/bash
 						set -x
@@ -188,16 +192,21 @@ pipeline {
 						export PATH=/opt/bin:${PATH}
 						export PATH=/opt/go/bin:${PATH}
 
-						autest_args=""
-						if [ -d ../cmake ]
-						then
+						if [ -x ../build/tests/urtest.sh ]; then
 							cd ../build/tests
-							pipenv install
+							./urtest.sh --no-run-in-docker
 						else
-							autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
-						fi
+							autest_args=""
+							if [ -d ../cmake ]
+							then
+								cd ../build/tests
+								pipenv install
+							else
+								autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
+							fi
 
-						./autest.sh ${autest_args}
+							./autest.sh ${autest_args}
+						fi
 						'''
 				}
 			}

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -95,23 +95,37 @@ pipeline {
 		}
 		stage('AuTest') {
 			steps {
-				echo 'Starting AuTest'
+				echo 'Starting end-to-end tests'
 				dir('src/build/tests') {
 					sh '''#!/bin/bash
 						#set +e
 						set -x
 						# We want to pick up the OpenSSL-QUIC version of curl in /opt/bin.
-						# The HTTP/3 AuTests depend upon this, so update the PATH accordingly.
+						# The HTTP/3 tests depend upon this, so update the PATH accordingly.
 						export PATH=/opt/bin:${PATH}
 						export PATH=/opt/go/bin:${PATH}
 
 						export_dir="${WORKSPACE}/output/${GITHUB_BRANCH}"
 						mkdir -p ${export_dir}
 
-						pipenv install
-						./autest.sh --sandbox /tmp/sandbox || true
+						test_failed=0
+						test_suite="Uranium"
+						if [ -x ./urtest.sh ]; then
+							./urtest.sh --no-run-in-docker || test_failed=1
+						else
+							test_suite="AuTest"
+							pipenv install
+							./autest.sh --sandbox /tmp/sandbox || test_failed=1
+						fi
 
-						if [ -n "$(ls -A /tmp/sandbox/)" ]; then
+						if [ ! -d /tmp/sandbox/ ]; then
+							echo "${test_suite} execution fundamentally failed. No tests were run."
+							touch ${export_dir}/Autest_failures
+							sudo chmod -R 777 ${WORKSPACE}
+							exit 1
+						elif [ ${test_failed} -ne 0 ] ||
+							{ [ "${test_suite}" = "AuTest" ] && [ -n "$(ls -A /tmp/sandbox/)" ]; }; then
+							echo "${test_suite} tests failed."
 							touch ${export_dir}/Autest_failures
 							cp -rf /tmp/sandbox/ "${export_dir}"
 							# Remove socket files so they don't break archiveArtifacts.

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -101,7 +101,15 @@ pipeline {
             if [ -d cmake ]
             then
               echo "Building with CMake."
-              cmake -B build --preset ${CMAKE_PRESET}
+              cmake_args=()
+              if [ -x tests/urtest.sh ]; then
+                if [ "${CMAKE_PRESET}" = "ci-fedora-autest" ]; then
+                  CMAKE_PRESET="ci-fedora-urtest"
+                fi
+                cmake_args+=("-DURTEST_SANDBOX=/tmp/sandbox")
+              fi
+              echo "Using CMake preset ${CMAKE_PRESET}."
+              cmake -B build --preset "${CMAKE_PRESET}" "${cmake_args[@]}"
               cmake --build build -j4 -v
               cmake --install build
             else
@@ -129,7 +137,7 @@ pipeline {
     }
     stage('AuTest') {
       steps {
-        echo 'Starting AuTest'
+        echo 'Starting test suite'
         dir('src/tests') {
           sh '''#!/bin/bash -x
             set +e
@@ -140,49 +148,56 @@ pipeline {
             export_dir="${WORKSPACE}/output/${GITHUB_PR_NUMBER}"
             mkdir -p ${export_dir}
 
-            autest_args=""
-            testsall=( $( find . -iname "*.test.py" | awk -F'/' '{print $NF}' | awk -F'.' '{print $1}' ) )
-
-            if [ -d ../cmake ]
-            then
+            test_failed=0
+            test_suite="Uranium"
+            if [ -x ../build/tests/urtest.sh ]; then
               cd ../build/tests
-              pipenv install
-              autest_args="--sandbox /tmp/sandbox"
+              ./urtest.sh --no-run-in-docker -n 2 || test_failed=1
             else
-              autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
-            fi
+              test_suite="AuTest"
+              autest_args=""
+              testsall=( $( find . -iname "*.test.py" | awk -F'/' '{print $NF}' | awk -F'.' '{print $1}' ) )
 
-            # Check for parallel support in autest.sh - originally added in 10.2.0.
-            if grep -q parallel_mode autest.sh; then
-              autest_args="-j 2 -v ${autest_args}"
-            fi
+              if [ -d ../cmake ]
+              then
+                cd ../build/tests
+                pipenv install
+                autest_args="--sandbox /tmp/sandbox"
+              else
+                autest_args="--ats-bin /tmp/ats/bin/ --sandbox /tmp/sandbox"
+              fi
 
-            autest_failed=0
-            if [ ${SHARDCNT} -le 0 ]; then
-              ./autest.sh ${autest_args} || autest_failed=1
-            else
-              testsall=( $(
-                for el in  "${testsall[@]}" ; do
-                  echo $el
-                done | sort) )
-              ntests=${#testsall[@]}
+              # Check for parallel support in autest.sh - originally added in 10.2.0.
+              if grep -q parallel_mode autest.sh; then
+                autest_args="-j 2 -v ${autest_args}"
+              fi
 
-              shardsize=$((${ntests} / ${SHARDCNT}))
-              [ 0 -ne $((${ntests} % ${shardsize})) ] && shardsize=$((${shardsize} + 1))
-              shardbeg=$((${shardsize} * ${SHARD}))
-              sliced=${testsall[@]:${shardbeg}:${shardsize}}
-              ./autest.sh ${autest_args} -f ${sliced[@]} || autest_failed=1
+              if [ ${SHARDCNT} -le 0 ]; then
+                ./autest.sh ${autest_args} || test_failed=1
+              else
+                testsall=( $(
+                  for el in  "${testsall[@]}" ; do
+                    echo $el
+                  done | sort) )
+                ntests=${#testsall[@]}
+
+                shardsize=$((${ntests} / ${SHARDCNT}))
+                [ 0 -ne $((${ntests} % ${shardsize})) ] && shardsize=$((${shardsize} + 1))
+                shardbeg=$((${shardsize} * ${SHARD}))
+                sliced=${testsall[@]:${shardbeg}:${shardsize}}
+                ./autest.sh ${autest_args} -f ${sliced[@]} || test_failed=1
+              fi
             fi
 
             if [ ! -d /tmp/sandbox/ ]; then
               # No sandbox. Probably a catastrophic failure, like an exception,
               # that prevented execution and the creation of a sandbox.
-              echo "AuTest execution fundamentally failed. No tests were run."
+              echo "${test_suite} execution fundamentally failed. No tests were run."
               touch ${export_dir}/Autest_failures
               sudo chmod -R 777 ${WORKSPACE}
               exit 1
-            elif [ ${autest_failed} -ne 0 ]; then
-              echo "AuTest tests failed."
+            elif [ ${test_failed} -ne 0 ]; then
+              echo "${test_suite} tests failed."
               touch ${export_dir}/Autest_failures
               cp -rf /tmp/sandbox/ "${export_dir}"
               # Remove socket files so they don't break archiveArtifacts.


### PR DESCRIPTION
ATS branches can expose either Uranium or AuTest CMake presets and
runners. Selecting only legacy names prevents migrated branches from
configuring, while dropping them would break maintained releases.

Detect the runner in each checkout, select matching presets and
invocations, and preserve AuTest sharding and artifacts for older
branches.