### PR TITLE
Show Uranium test progress

### DIFF
--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -153,7 +153,7 @@ pipeline {
 						test_suite="Uranium"
 						if [ -x ../build/tests/urtest.sh ]; then
 							cd ../build/tests
-							./urtest.sh --no-run-in-docker -n 2 || test_failed=1
+							./urtest.sh --no-run-in-docker -v -n 2 || test_failed=1
 						else
 							test_suite="AuTest"
 							autest_args=""

--- a/jenkins/branch/coverage.pipeline
+++ b/jenkins/branch/coverage.pipeline
@@ -194,7 +194,7 @@ pipeline {
 
 						if [ -x ../build/tests/urtest.sh ]; then
 							cd ../build/tests
-							./urtest.sh --no-run-in-docker
+							./urtest.sh --no-run-in-docker -v
 						else
 							autest_args=""
 							if [ -d ../cmake ]

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -111,7 +111,7 @@ pipeline {
 						test_failed=0
 						test_suite="Uranium"
 						if [ -x ./urtest.sh ]; then
-							./urtest.sh --no-run-in-docker || test_failed=1
+							./urtest.sh --no-run-in-docker -v || test_failed=1
 						else
 							test_suite="AuTest"
 							pipenv install

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -152,7 +152,7 @@ pipeline {
             test_suite="Uranium"
             if [ -x ../build/tests/urtest.sh ]; then
               cd ../build/tests
-              ./urtest.sh --no-run-in-docker -n 2 || test_failed=1
+              ./urtest.sh --no-run-in-docker -v -n 2 || test_failed=1
             else
               test_suite="AuTest"
               autest_args=""


### PR DESCRIPTION
Uranium's default pytest output does not identify individual tests as
they complete. Long CI runs therefore appear idle and make it hard to
see which scenario is running or failed.

This enables verbose pytest reporting for every Uranium CI invocation
so each completed test emits one status line. AuTest invocations remain
unchanged.