### PR TITLE
Archive only failed test artifacts

### DIFF
--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -147,7 +147,7 @@ pipeline {
 						export PATH=/opt/go/bin:${PATH}
 
 						export_dir="${WORKSPACE}/output/${GITHUB_BRANCH}"
-						mkdir -p ${export_dir}
+						sudo rm -rf "${export_dir}"
 
 						test_failed=0
 						test_suite="Uranium"
@@ -189,13 +189,16 @@ pipeline {
 							# No sandbox. Probably a catastrophic failure, like an exception,
 							# that prevented execution and the creation of a sandbox.
 							echo "${test_suite} execution fundamentally failed. No tests were run."
-							touch ${export_dir}/Autest_failures
+							mkdir -p "${export_dir}"
+							touch "${export_dir}/Autest_failures"
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						elif [ ${test_failed} -ne 0 ] ||
 							{ [ "${test_suite}" = "AuTest" ] && [ -n "$(ls -A /tmp/sandbox/)" ]; }; then
 							echo "${test_suite} tests failed."
-							touch ${export_dir}/Autest_failures
+							mkdir -p "${export_dir}"
+							touch "${export_dir}/Autest_failures"
+							sudo chmod -R a+rX /tmp/sandbox/
 							cp -rf /tmp/sandbox/ "${export_dir}"
 							# Remove socket files so they don't break archiveArtifacts.
 							find "${export_dir}" -type s -delete
@@ -203,7 +206,6 @@ pipeline {
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						else
-							touch ${export_dir}/No_autest_failures
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 0
 						fi
@@ -214,10 +216,10 @@ pipeline {
 	}
 
 	post {
-		always {
+		failure {
 			// We exclude socket files because archiveArtifacts doesn't deal well with
 			// their file type.
-			archiveArtifacts artifacts: 'output/**/*', fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock, **/*.socket, **/cache.db'
+			archiveArtifacts artifacts: "output/${GITHUB_BRANCH}/**/*", fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock, **/*.socket, **/cache.db'
 		}
 		cleanup {
 			cleanWs()

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -106,7 +106,7 @@ pipeline {
 						export PATH=/opt/go/bin:${PATH}
 
 						export_dir="${WORKSPACE}/output/${GITHUB_BRANCH}"
-						mkdir -p ${export_dir}
+						sudo rm -rf "${export_dir}"
 
 						test_failed=0
 						test_suite="Uranium"
@@ -120,13 +120,16 @@ pipeline {
 
 						if [ ! -d /tmp/sandbox/ ]; then
 							echo "${test_suite} execution fundamentally failed. No tests were run."
-							touch ${export_dir}/Autest_failures
+							mkdir -p "${export_dir}"
+							touch "${export_dir}/Autest_failures"
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						elif [ ${test_failed} -ne 0 ] ||
 							{ [ "${test_suite}" = "AuTest" ] && [ -n "$(ls -A /tmp/sandbox/)" ]; }; then
 							echo "${test_suite} tests failed."
-							touch ${export_dir}/Autest_failures
+							mkdir -p "${export_dir}"
+							touch "${export_dir}/Autest_failures"
+							sudo chmod -R a+rX /tmp/sandbox/
 							cp -rf /tmp/sandbox/ "${export_dir}"
 							# Remove socket files so they don't break archiveArtifacts.
 							find "${export_dir}" -type s -delete
@@ -134,7 +137,6 @@ pipeline {
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1
 						else
-							touch ${export_dir}/No_autest_failures
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 0
 						fi
@@ -144,10 +146,10 @@ pipeline {
 		}
 	}
 	post {
-		always {
+		failure {
 			// We exclude socket files because archiveArtifacts doesn't deal well with
 			// their file type.
-			archiveArtifacts artifacts: 'output/**/*', fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock, **/*.socket, **/cache.db'
+			archiveArtifacts artifacts: "output/${GITHUB_BRANCH}/**/*", fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock, **/*.socket, **/cache.db'
 		}
 		cleanup {
 			cleanWs()

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -146,7 +146,7 @@ pipeline {
             export PATH=/opt/go/bin:${PATH}
 
             export_dir="${WORKSPACE}/output/${GITHUB_PR_NUMBER}"
-            mkdir -p ${export_dir}
+            sudo rm -rf "${export_dir}"
 
             test_failed=0
             test_suite="Uranium"
@@ -193,12 +193,15 @@ pipeline {
               # No sandbox. Probably a catastrophic failure, like an exception,
               # that prevented execution and the creation of a sandbox.
               echo "${test_suite} execution fundamentally failed. No tests were run."
-              touch ${export_dir}/Autest_failures
+              mkdir -p "${export_dir}"
+              touch "${export_dir}/Autest_failures"
               sudo chmod -R 777 ${WORKSPACE}
               exit 1
             elif [ ${test_failed} -ne 0 ]; then
               echo "${test_suite} tests failed."
-              touch ${export_dir}/Autest_failures
+              mkdir -p "${export_dir}"
+              touch "${export_dir}/Autest_failures"
+              sudo chmod -R a+rX /tmp/sandbox/
               cp -rf /tmp/sandbox/ "${export_dir}"
               # Remove socket files so they don't break archiveArtifacts.
               find "${export_dir}" -type s -delete
@@ -206,7 +209,6 @@ pipeline {
               sudo chmod -R 777 ${WORKSPACE}
               exit 1
             else
-              touch ${export_dir}/No_autest_failures
               sudo chmod -R 777 ${WORKSPACE}
               exit 0
             fi
@@ -217,7 +219,7 @@ pipeline {
   }
 
   post {
-    always {
+    failure {
       // We exclude socket files because archiveArtifacts doesn't deal well with
       // their file type.
       archiveArtifacts artifacts: "output/${GITHUB_PR_NUMBER}/**/*", fingerprint: false, allowEmptyArchive: true, excludes: '**/*.sock, **/*.socket, **/cache.db'


### PR DESCRIPTION
Successful test runs still invoked Jenkins artifact archiving. Failed
runs could also encounter unreadable sandbox files while copying
diagnostics. Passing jobs therefore did needless work, while failure
publication was slow or incomplete.

This patch publishes artifacts only when the build fails, clears stale
output before each run, and makes sandbox diagnostics readable before
copying them. It applies to PR, branch, and Quiche jobs while retaining
AuTest compatibility.