### PR TITLE
Preserve test sandbox permissions

### DIFF
--- a/jenkins/bin/quiche.sh
+++ b/jenkins/bin/quiche.sh
@@ -36,6 +36,10 @@ fi
 
 cd "${WORKSPACE}/src"
 
+# Config installation preserves source modes. Ensure a restrictive checkout
+# umask cannot make installed defaults unreadable.
+sudo chmod -R o+r .
+
 # copy in CMakePresets.json
 presetpath="../ci/jenkins/branch/CMakePresets.json"
 [ -f "${presetpath}" ] && /bin/cp -f "${presetpath}" .

--- a/jenkins/branch/autest.pipeline
+++ b/jenkins/branch/autest.pipeline
@@ -90,6 +90,10 @@ pipeline {
 						# Pick up supplemental CI tools installed in /opt/bin.
 						export PATH=/opt/bin:${PATH}
 
+						# Config installation preserves source modes. Ensure a restrictive
+						# checkout umask cannot make installed defaults unreadable.
+						sudo chmod -R o+r .
+
 						NPROC=$(nproc)
 
 						if [ -d cmake ]
@@ -115,8 +119,6 @@ pipeline {
 						else
 							echo "Building with autotools"
 
-							# Change permissions so that all files are readable
-							# (default user umask may change and make these unreadable)
 							autoreconf -fiv
 							./configure \
 								--enable-experimental-plugins \
@@ -198,10 +200,14 @@ pipeline {
 							echo "${test_suite} tests failed."
 							mkdir -p "${export_dir}"
 							touch "${export_dir}/Autest_failures"
-							sudo chmod -R a+rX /tmp/sandbox/
-							cp -rf /tmp/sandbox/ "${export_dir}"
-							# Remove socket files so they don't break archiveArtifacts.
-							find "${export_dir}" -type s -delete
+							# Preserve sandbox ownership and modes before the workspace is
+							# made writable for Jenkins cleanup. Tar cannot store sockets;
+							# cache.db was already excluded from archived artifacts.
+							sudo tar \
+								--exclude='*.sock' \
+								--exclude='*.socket' \
+								--exclude='*/cache.db' \
+								-C /tmp -czf "${export_dir}/sandbox.tar.gz" sandbox
 							ls "${export_dir}"
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1

--- a/jenkins/branch/quiche.pipeline
+++ b/jenkins/branch/quiche.pipeline
@@ -129,10 +129,14 @@ pipeline {
 							echo "${test_suite} tests failed."
 							mkdir -p "${export_dir}"
 							touch "${export_dir}/Autest_failures"
-							sudo chmod -R a+rX /tmp/sandbox/
-							cp -rf /tmp/sandbox/ "${export_dir}"
-							# Remove socket files so they don't break archiveArtifacts.
-							find "${export_dir}" -type s -delete
+							# Preserve sandbox ownership and modes before the workspace is
+							# made writable for Jenkins cleanup. Tar cannot store sockets;
+							# cache.db was already excluded from archived artifacts.
+							sudo tar \
+								--exclude='*.sock' \
+								--exclude='*.socket' \
+								--exclude='*/cache.db' \
+								-C /tmp -czf "${export_dir}/sandbox.tar.gz" sandbox
 							ls "${export_dir}"
 							sudo chmod -R 777 ${WORKSPACE}
 							exit 1

--- a/jenkins/github/autest.pipeline
+++ b/jenkins/github/autest.pipeline
@@ -98,6 +98,10 @@ pipeline {
             # Pick up supplemental CI tools installed in /opt/bin.
             export PATH=/opt/bin:${PATH}
 
+            # Config installation preserves source modes. Ensure a restrictive
+            # checkout umask cannot make installed defaults unreadable.
+            sudo chmod -R o+r .
+
             if [ -d cmake ]
             then
               echo "Building with CMake."
@@ -116,9 +120,6 @@ pipeline {
               echo "CMake builds are not supported for this branch."
               echo "Building with autotools instead."
 
-              # Change permissions so that all files are readable
-              # (default user umask may change and make these unreadable)
-              sudo chmod -R o+r .
               autoreconf -fiv
               ./configure \
                 --enable-experimental-plugins \
@@ -201,10 +202,14 @@ pipeline {
               echo "${test_suite} tests failed."
               mkdir -p "${export_dir}"
               touch "${export_dir}/Autest_failures"
-              sudo chmod -R a+rX /tmp/sandbox/
-              cp -rf /tmp/sandbox/ "${export_dir}"
-              # Remove socket files so they don't break archiveArtifacts.
-              find "${export_dir}" -type s -delete
+              # Preserve sandbox ownership and modes before the workspace is
+              # made writable for Jenkins cleanup. Tar cannot store sockets;
+              # cache.db was already excluded from archived artifacts.
+              sudo tar \
+                --exclude='*.sock' \
+                --exclude='*.socket' \
+                --exclude='*/cache.db' \
+                -C /tmp -czf "${export_dir}/sandbox.tar.gz" sandbox
               ls "${export_dir}"
               sudo chmod -R 777 ${WORKSPACE}
               exit 1


### PR DESCRIPTION
Restrictive checkout modes can make CMake-installed defaults unreadable,
causing runroot verification to fail. The failed-artifact path then
rewrites sandbox modes before archiving and erases the evidence.

This patch normalizes source readability before end-to-end builds and
packages failed sandboxes before workspace cleanup changes permissions.
The tar keeps complete sandbox contents while continuing to omit sockets
and cache.db.
